### PR TITLE
expo-sqlite does not support web

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -2848,7 +2848,7 @@
     "githubUrl": "https://github.com/expo/expo/tree/master/packages/expo-sqlite",
     "ios": true,
     "android": true,
-    "web": true,
+    "web": false,
     "expo": true
   },
   {


### PR DESCRIPTION
# Why

The websql RFC is now deprecated and Expo's documentation [lists this](https://docs.expo.io/versions/v37.0.0/sdk/sqlite/) as unsupported.