### PR TITLE
add 'macOS' platform to 'async-storage'

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3459,6 +3459,7 @@
     "web": false,
     "expo": false,
     "windows": true,
+    "macos": true,
     "unmaintained": false,
     "npmPkg": "@react-native-community/async-storage"
   },


### PR DESCRIPTION
# Why

This small PR adds 'macOS' to the supported platforms by 'async-storage'.

Refs: https://github.com/react-native-community/async-storage/releases/tag/v1.8.1

# Checklist

<!--
Check completed item, when applicable, via: [X]
-->

If you added a new library:

- [ ] Added it to **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
