### PR TITLE
fix sort select appearance on Windows

### DIFF
--- a/components/Sort.tsx
+++ b/components/Sort.tsx
@@ -64,7 +64,12 @@ export const SortButton = (props: SortButtonProps) => {
         <P style={styles.title}>
           <Picker selectedValue={sortValue} style={styles.picker} onValueChange={onPickerChange}>
             {sorts.map(sort => (
-              <Picker.Item key={sort.param} value={sort.param} label={sort.label} />
+              <Picker.Item
+                key={sort.param}
+                value={sort.param}
+                label={sort.label}
+                color={colors.black}
+              />
             ))}
           </Picker>
         </P>


### PR DESCRIPTION
# Why

This small PR fixes the sort select appearance on Windows (Chrome, Edge, Opera). Options inherits the `color` style of the  `Picker` so on Windows text inside options list were white. This change or any other `Picker.Item` color property is not affecting macOS since system context menu (not the browser implementation) is used there.

# Checklist

<!--
Check completed item, when applicable, via: [X]
-->

If you added a new library:

- [ ] Added it to **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.

# Preview

### Before
![Untitled-2](https://user-images.githubusercontent.com/719641/82952413-35419000-9fa9-11ea-89d9-681d72a39a07.png)

### After
![Untitled-1](https://user-images.githubusercontent.com/719641/82952393-2eb31880-9fa9-11ea-933f-b1b3920c4bdb.png)
