### PR TITLE
remove 'react-native-macos' entry

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -4783,12 +4783,6 @@
     "unmaintained": false
   },
   {
-    "githubUrl": "https://github.com/ptmt/react-native-macos",
-    "macos": true,
-    "npmPkg": "react-native-macos",
-    "unmaintained": false
-  },
-  {
     "githubUrl": "https://github.com/Microsoft/reactxp",
     "ios": true,
     "android": true,


### PR DESCRIPTION
# Why

This PR removes the 'react-native-macos' entry because:
* it's a platform not a library
* it's an old and unmaintained fork of RN for macOS which has been replaced by Microsoft fork (`microsoft/react-native-macos`)

# Checklist

If you added a new library:

- [ ] Added it to **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
