### PR TITLE
add '@react-native-community/slider' package

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1017,7 +1017,8 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/H1cnedhBW"]
+    "examples": ["https://snack.expo.io/H1cnedhBW"],
+    "unmaintained": true
   },
   {
     "githubUrl": "https://github.com/sbycrosz/react-native-credit-card-input",
@@ -5088,5 +5089,16 @@
     "npmPkg": "rn-tourguide",
     "unmaintained": false,
     "examples": ["https://github.com/xcarpentier/rn-tourguide/blob/master/App.tsx"]
+  },
+  {
+    "githubUrl": "https://github.com/react-native-community/react-native-slider",
+    "npmPkg": "@react-native-community/slider",
+    "images": [
+      "https://i.postimg.cc/dQTYzGD5/Screenshot-2019-03-25-at-11-24-59.png", 
+      "https://i.postimg.cc/CKdtbVqc/Screenshot-2019-03-25-at-11-26-54.png"
+    ],
+    "ios": true,
+    "android": true,
+    "web": true 
   }
 ]


### PR DESCRIPTION
# Why

This PR adds `@react-native-community/slider` package to the repository.

I have also marked `react-native-slider` as an unmaintained because last commit and release was almost 2 years ago.

# Checklist

If you added a new library:

- [X] Added it to **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.
