### PR TITLE
display 'npmPkg' name if provided, search also in the 'npmPkg' content

### DIFF
--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -23,7 +23,7 @@ export default function Library(props: Props) {
             href={library.githubUrl || library.github.urls.repo}
             style={styles.name}
             hoverStyle={styles.nameHovered}>
-            {library.github.name}
+            {library.npmPkg || library.github.name}
           </A>
           {library.goldstar && (
             <View style={[styles.displayHorizontal, styles.recommendedContainer]}>

--- a/util/search.js
+++ b/util/search.js
@@ -53,11 +53,14 @@ export const handleFilterLibraries = ({ libraries, queryTopic, querySearch, supp
       const isNameMatch = !isEmptyOrNull(library.github.name)
         ? library.github.name.includes(querySearch)
         : undefined;
+      const isNpmPkgNameMatch = !isEmptyOrNull(library.npmPkg)
+        ? library.npmPkg.includes(querySearch)
+        : undefined;
       const isDescriptionMatch = !isEmptyOrNull(library.github.description)
         ? library.github.description.includes(querySearch)
         : undefined;
 
-      isSearchMatch = isNameMatch || isDescriptionMatch || isTopicMatch;
+      isSearchMatch = isNameMatch || isNpmPkgNameMatch || isDescriptionMatch || isTopicMatch;
     }
 
     if (!viewerHasChosenTopic) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

This PR adds a feature which display the NPM package name (if provided) before the GitHub name which should help with "duplicated" entries and confusion of the users and contributors.

Additionally `npmPkg` property has been added to the search to checks so, for example `@react-native-community` is a valid search term now.

# Checklist

<!--
Check completed item, when applicable, via: [X]
-->

If you added a new library:

- [ ] Added it to **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.

# Preview
<img width="983" alt="Annotation 2020-05-30 123132" src="https://user-images.githubusercontent.com/719641/83326108-8edbe000-a271-11ea-80c7-438113e3d88c.png">
