### PR TITLE
sort platforms alphabetically

### DIFF
--- a/components/CompatibilityTags.tsx
+++ b/components/CompatibilityTags.tsx
@@ -11,12 +11,12 @@ type Props = {
 export function CompatibilityTags(props: Props) {
   const { library } = props;
   const platforms = [
-    library.ios ? 'iOS' : null,
     library.android ? 'Android' : null,
-    library.windows ? 'Windows' : null,
+    library.expo && typeof library.expo !== 'string' ? 'Expo client' : null,
+    library.ios ? 'iOS' : null,
     library.macos ? 'macOS' : null,
     library.web ? 'Web' : null,
-    library.expo && typeof library.expo !== 'string' ? 'Expo client' : null,
+    library.windows ? 'Windows' : null,
   ]
     .map(platform => platform)
     .filter(Boolean);

--- a/components/Filters.tsx
+++ b/components/Filters.tsx
@@ -19,12 +19,20 @@ type FilterButtonProps = {
 
 const platforms = [
   {
+    param: 'android',
+    title: 'Android',
+  },
+  {
+    param: 'expo',
+    title: 'Expo Client',
+  },
+  {
     param: 'ios',
     title: 'iOS',
   },
   {
-    param: 'android',
-    title: 'Android',
+    param: 'macos',
+    title: 'macOS',
   },
   {
     param: 'web',
@@ -33,14 +41,6 @@ const platforms = [
   {
     param: 'windows',
     title: 'Windows',
-  },
-  {
-    param: 'macos',
-    title: 'macOS',
-  },
-  {
-    param: 'expo',
-    title: 'Expo Client',
   },
 ];
 


### PR DESCRIPTION
# Why

This PR sorts the platforms in the alphabetical order in the filters and libraries boxes. The currently used order was a bit ambiguous and may seems a bit random (form the code I can assume that it was just based on the platforms addition time). The alphabetical sort is fair and intuitive for the users, the same approach has been introduced on the RN website not that long ago.

I was thinking about updating the Readme file and JSON schema too but I think that the order in there is not that crucial. Of course feel free to correct me if I'm wrong.

# Checklist

If you added a new library:

- [ ] Added it to **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.

# Preview
<img width="980" alt="Annotation 2020-05-30 134400" src="https://user-images.githubusercontent.com/719641/83327386-a750f800-a27b-11ea-9688-ac53761f77e1.png">
