### PR TITLE
fix images container overflow

### DIFF
--- a/components/Library/Thumbnail.tsx
+++ b/components/Library/Thumbnail.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useRef, useState } from 'react';
-import ReactDOM from 'react-dom';
+import { createPortal } from 'react-dom';
 import { usePopper } from 'react-popper';
 import { Thumbnail as ThumbnailIcon } from '../Icons';
 import { colors } from '../../common/styleguide';
@@ -28,11 +28,11 @@ const Thumbnail = ({ url }: Props) => {
         ref={iconRef}
         onMouseOver={handleMouseEvent}
         onMouseOut={handleMouseEvent}
-        style={{ marginRight: 15 }}>
+        style={{ marginRight: 15, marginBottom: 8 }}>
         <ThumbnailIcon fill={showPreview ? colors.primary : undefined} />
       </a>
 
-      {ReactDOM.createPortal(
+      {createPortal(
         <div ref={previewRef} style={styles.popper} {...attributes.popper}>
           {showPreview && (
             <div className="preview">

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -137,7 +137,9 @@ let styles = StyleSheet.create({
     marginTop: 12,
   },
   imagesContainer: {
-    marginVertical: 20,
+    flexWrap: 'wrap',
+    marginTop: 20,
+    marginBottom: 12,
     marginLeft: 2,
   },
 });


### PR DESCRIPTION
# Why

When there is a lot of images for the library the images container do not wrap its content which causes an overflow (and the images under MetaData are non accessible. The example of such library is `react-native-maps`. The changes included in this PR fixes that issue.

### Before
<img width="891" alt="Annotation 2020-06-07 011911" src="https://user-images.githubusercontent.com/719641/83970906-8e2df400-a8d8-11ea-8372-55d9fba9da26.png">

### After
<img width="885" alt="Annotation 2020-06-07 012257" src="https://user-images.githubusercontent.com/719641/83970901-8a9a6d00-a8d8-11ea-8b47-0d20bbc260ec.png">


# Checklist

<!--
Check completed item, when applicable, via: [X]
-->

If you added a new library:

- [ ] Added it to **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.
