### PR TITLE
Add react-native-network-logger

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -5139,5 +5139,18 @@
     "windows": false,
     "macos": false,
     "unmaintained": false
+  },
+  {
+    "githubUrl": "https://github.com/alexbrazier/react-native-network-logger",
+    "npmPkg": "react-native-network-logger",
+    "examples": ["https://github.com/alexbrazier/react-native-network-logger/tree/master/example"],
+    "images": ["https://raw.githubusercontent.com/alexbrazier/react-native-network-logger/master/.github/images/ios-details.png"],
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": true,
+    "windows": false,
+    "macos": false,
+    "unmaintained": false
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -5144,7 +5144,10 @@
     "githubUrl": "https://github.com/alexbrazier/react-native-network-logger",
     "npmPkg": "react-native-network-logger",
     "examples": ["https://github.com/alexbrazier/react-native-network-logger/tree/master/example"],
-    "images": ["https://raw.githubusercontent.com/alexbrazier/react-native-network-logger/master/.github/images/ios-details.png"],
+    "images": [
+      "https://raw.githubusercontent.com/alexbrazier/react-native-network-logger/master/.github/images/ios-list.png",
+      "https://raw.githubusercontent.com/alexbrazier/react-native-network-logger/master/.github/images/ios-details.png"
+    ],
     "ios": true,
     "android": true,
     "web": false,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

Add new library that allows you to monitor and view network requests on iOS and Android apps with react native.

https://github.com/alexbrazier/react-native-network-logger

- [x] Added it to **react-native-libraries.json**
