### PR TITLE
show activity indicator before image is loaded

### DIFF
--- a/components/Library/Thumbnail.tsx
+++ b/components/Library/Thumbnail.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useCallback, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { usePopper } from 'react-popper';
+import { ActivityIndicator } from 'react-native';
 import { Thumbnail as ThumbnailIcon } from '../Icons';
 import { colors } from '../../common/styleguide';
 
@@ -10,6 +11,7 @@ type Props = {
 
 const Thumbnail = ({ url }: Props) => {
   const [showPreview, setShowPreview] = useState(false);
+  const [isLoaded, setLoaded] = useState(false);
   const iconRef = useRef();
   const previewRef = useRef();
 
@@ -31,12 +33,12 @@ const Thumbnail = ({ url }: Props) => {
         style={{ marginRight: 15, marginBottom: 8 }}>
         <ThumbnailIcon fill={showPreview ? colors.primary : undefined} />
       </a>
-
       {createPortal(
         <div ref={previewRef} style={styles.popper} {...attributes.popper}>
           {showPreview && (
-            <div className="preview">
-              <img src={url} />
+            <div className={'preview' + (isLoaded ? ' loaded' : '')}>
+              {isLoaded ? null : <ActivityIndicator size="small" />}
+              <img src={url} onLoad={() => setLoaded(true)} />
             </div>
           )}
         </div>,

--- a/styles/PreviewStyles.tsx
+++ b/styles/PreviewStyles.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useDimensions } from 'react-native-web-hooks';
-import { colors } from '../common/styleguide';
 
 const GITHUB_PREVIEW_MIN_WIDTH = 640;
 
@@ -24,7 +23,12 @@ const PreviewStyles = () => {
       }
 
       .preview img {
+        display: none;
         max-width: ${previewImageWidth}px;
+      }
+
+      .preview.loaded img {
+        display: block;
       }
     `}</style>
   );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

This PR adds small UI tweak - activity indicator is displayed in the popper portal before the image is loaded.

### Preview
![500](https://user-images.githubusercontent.com/719641/85228668-015d5d00-b3e5-11ea-885d-6b029f6380a4.gif)

# Checklist

If you added a new library:

- [ ] Added it to **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.
