### PR TITLE
adds directory score explanation

### DIFF
--- a/components/ContentContainer.tsx
+++ b/components/ContentContainer.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode } from 'react';
+import { View, StyleSheet, ViewStyle } from 'react-native';
+
+import { layout } from '../common/styleguide';
+
+type Props = {
+  children: ReactNode;
+  style?: ViewStyle;
+};
+
+export default function ContentContainer(props: Props) {
+  const { children, style } = props;
+  return <View style={[styles.container, style]}>{children}</View>;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    width: '100%',
+    maxWidth: layout.maxWidth,
+    margin: 'auto',
+  },
+});

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,21 +1,25 @@
 import React from 'react';
 import { Text, StyleSheet, View } from 'react-native';
-import { A } from '../common/styleguide';
+
+import { A, colors } from '../common/styleguide';
+import ContentContainer from '../components/ContentContainer';
 
 export default function Footer() {
   return (
     <View style={styles.container}>
-      <Text style={{ lineHeight: 22 }}>
-        Missing a library?{' '}
-        <A href="https://github.com/react-native-community/react-native-directory#how-do-i-add-a-library">
-          Add it to the directory
-        </A>
-        . Want to learn more about React Native? Check out the{' '}
-        <A href="https://facebook.github.io/react-native/docs/getting-started.html">
-          official React Native docs
-        </A>
-        , and <A href="https://expo.io">Expo</A>.
-      </Text>
+      <ContentContainer>
+        <Text style={{ lineHeight: 22 }}>
+          Missing a library?{' '}
+          <A href="https://github.com/react-native-community/react-native-directory#how-do-i-add-a-library">
+            Add it to the directory
+          </A>
+          . Want to learn more about React Native? Check out the{' '}
+          <A href="https://facebook.github.io/react-native/docs/getting-started.html">
+            official React Native docs
+          </A>
+          , and <A href="https://expo.io">Expo</A>.
+        </Text>
+      </ContentContainer>
     </View>
   );
 }
@@ -28,6 +32,6 @@ let styles = StyleSheet.create({
     marginBottom: 10,
     borderTopWidth: 1,
     marginTop: 10,
-    borderTopColor: '#ececec',
+    borderTopColor: colors.gray2,
   },
 });

--- a/components/Library/MetaData.tsx
+++ b/components/Library/MetaData.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
+
+import { colors, A, Caption } from '../../common/styleguide';
 import { Library as LibraryType } from '../../types';
 import { getTimeSinceToday } from '../../util/datetime';
-import { colors, A, Caption } from '../../common/styleguide';
 import { Calendar, Star, Download, Issue, Web } from '../Icons';
 import { DirectoryScore } from './DirectoryScore';
 
@@ -17,7 +18,11 @@ export function MetaData(props: Props) {
     {
       id: 'score',
       icon: <DirectoryScore score={library.score} />,
-      content: 'Directory score',
+      content: (
+        <A target="" href="/directory-score" style={styles.directoryScoreLink}>
+          Directory Score
+        </A>
+      ),
     },
     {
       id: 'calendar',
@@ -86,5 +91,8 @@ const styles = StyleSheet.create({
     marginRight: 8,
     width: 20,
     alignItems: 'center',
+  },
+  directoryScoreLink: {
+    backgroundColor: 'transparent',
   },
 });

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,17 +1,15 @@
-import React from 'react';
 import * as Sentry from '@sentry/node';
 import Head from 'next/head';
-import { View } from 'react-native';
+import React from 'react';
 import { AppearanceProvider } from 'react-native-appearance';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import CustomAppearanceProvider from '../context/CustomAppearanceProvider';
+
 import Favicon from '../components/Favicon';
+import Footer from '../components/Footer';
 import GoogleAnalytics from '../components/GoogleAnalytics';
 import Header from '../components/Header';
-import Search from '../components/Search';
-import Footer from '../components/Footer';
+import CustomAppearanceProvider from '../context/CustomAppearanceProvider';
 import PreviewStyles from '../styles/PreviewStyles';
-import * as Styleguide from '../common/styleguide';
 
 Sentry.init({
   dsn: 'https://b084338633454a63a82c787541b96d8f@sentry.io/2503319',
@@ -26,7 +24,7 @@ const site = {
 const themeColor = '#fff';
 
 export default function App(props: any) {
-  let { pageProps, Component, router } = props;
+  let { pageProps, Component } = props;
   return (
     <>
       <Head>
@@ -45,17 +43,8 @@ export default function App(props: any) {
             <>
               <Favicon />
               <Header />
-              <Search query={router.query} total={pageProps.data && pageProps.data.total} />
-              <View
-                style={{
-                  flex: 1,
-                  width: '100%',
-                  maxWidth: Styleguide.layout.maxWidth,
-                  margin: 'auto',
-                }}>
-                <Component {...pageProps} />
-                <Footer />
-              </View>
+              <Component {...pageProps} />
+              <Footer />
             </>
           </CustomAppearanceProvider>
         </AppearanceProvider>

--- a/pages/directory-score.tsx
+++ b/pages/directory-score.tsx
@@ -35,7 +35,7 @@ function DirectoryScore(props) {
         Libraries with a popularity score of over 10,000 meet this criterion. Popularity is measured
         by weighting and combining subscribers, forks, stars, and download counts.
       </P>
-      <Headline style={styles.criterion}>Popular (+20)</Headline>
+      <Headline style={styles.criterion}>Popular (+10)</Headline>
       <P style={styles.paragraph}>
         Libraries with a popularity score of over 2,500 meet this criterion. Popularity is measured
         by weighting and combining subscribers, forks, stars, and download counts.

--- a/pages/directory-score.tsx
+++ b/pages/directory-score.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { H1, H2, H3, P, Headline, A, colors } from '../common/styleguide';
+import ContentContainer from '../components/ContentContainer';
+
+// type Props = {};
+
+function DirectoryScore(props) {
+  return (
+    <ContentContainer style={styles.container}>
+      <H1 style={styles.header}>Directory Score</H1>
+      <P style={styles.paragraph}>
+        The Directory Score is the combination of multiple factors that relate to the quality of a
+        library. A library can earn value by exhibiting "good behavior criteria" and can lose value
+        by exhibiting "bad behavior criteria". These criteria and their corresponding weights are
+        detailed below. You can see the code this directory uses to create Directory Scores{' '}
+        <A href="https://github.com/react-native-directory/website/blob/master/scripts/calculate-score.js">
+          here
+        </A>
+        .
+      </P>
+      <P style={[styles.paragraph, styles.callout]}>
+        Directory Scores are subjective and are based on data that's readily available on GitHub.
+        It's not a perfect score and may not reflect quality for your specific needs. When
+        evaluating libraries to include in your project, review the library yourself to determine if
+        it's a good fit.
+      </P>
+      <H2 style={styles.subHeader}>Scoring criteria</H2>
+      <P style={styles.paragraph}>
+        The following criteria are used to calculate a library's Directory Score.
+      </P>
+      <Headline style={styles.criterion}>Very popular (+40)</Headline>
+      <P style={styles.paragraph}>
+        Libraries with a popularity score of over 10,000 meet this criterion. Popularity is measured
+        by weighting and combining subscribers, forks, stars, and download counts.
+      </P>
+      <Headline style={styles.criterion}>Popular (+20)</Headline>
+      <P style={styles.paragraph}>
+        Libraries with a popularity score of over 2,500 meet this criterion. Popularity is measured
+        by weighting and combining subscribers, forks, stars, and download counts.
+      </P>
+      <Headline style={styles.criterion}>Recommended (+20)</Headline>
+      <P style={styles.paragraph}>
+        The maintainers of React Native Directory hand pick select recommended libraries.
+      </P>
+      <Headline style={styles.criterion}>Recently updated (+10)</Headline>
+      <P style={styles.paragraph}>
+        Libraries that have been updated in the last 30 days meet this criterion.
+      </P>
+      <Headline style={styles.criterion}>Not updated recently (-10)</Headline>
+      <P style={styles.paragraph}>
+        Libraries that have not been updated in the last 180 days meet this criterion.
+      </P>
+      <Headline style={styles.criterion}>Lots of open issues (-20)</Headline>
+      <P style={styles.paragraph}>Libraries with more than 75 open issues meet this criterion.</P>
+      <Headline style={styles.criterion}>No license or GPL license (-20)</Headline>
+      <P style={styles.paragraph}>
+        Libraries without a license or that include the GPL license meet this criterion.
+      </P>
+    </ContentContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 32,
+    paddingHorizontal: 16,
+  },
+  header: {
+    marginBottom: 20,
+  },
+  subHeader: {
+    marginTop: 16,
+    marginBottom: 20,
+  },
+  paragraph: {
+    fontSize: 17,
+    color: '#1a1a1a',
+    lineHeight: 29,
+    marginBottom: 17,
+  },
+  callout: {
+    backgroundColor: colors.warningLight,
+    borderLeftWidth: 8,
+    borderLeftColor: colors.warning,
+    padding: 16,
+    marginBottom: 17,
+  },
+  criterion: {
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+});
+
+export default DirectoryScore;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,21 +1,31 @@
-import * as React from 'react';
 import fetch from 'isomorphic-fetch';
 import { NextPageContext } from 'next';
+import { useRouter } from 'next/router';
+import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
+
+import ContentContainer from '../components/ContentContainer';
 import Libraries from '../components/Libraries';
 import Pagination from '../components/Pagination';
+import Search from '../components/Search';
 import getApiUrl from '../util/getApiUrl';
 import urlWithQuery from '../util/urlWithQuery';
 
 export default function App(props) {
   const { data, query } = props;
+  const router = useRouter();
 
   return (
-    <View style={styles.container}>
-      <Pagination query={query} total={data && data.total} />
-      <Libraries libraries={data && data.libraries} />
-      <Pagination query={query} total={data && data.total} />
-    </View>
+    <>
+      <Search query={router.query} total={data && data.total} />
+      <ContentContainer>
+        <View style={styles.container}>
+          <Pagination query={query} total={data && data.total} />
+          <Libraries libraries={data && data.libraries} />
+          <Pagination query={query} total={data && data.total} />
+        </View>
+      </ContentContainer>
+    </>
   );
 }
 

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -5108,8 +5108,15 @@
   {
     "githubUrl": "https://github.com/react-native-toolkit/triangle",
     "npmPkg": "@react-native-toolkit/triangle",
-    "examples": ["https://expo.io/@daniakash/TriangleExample", "https://react-native-toolkit.github.io/triangle/", "https://codesandbox.io/s/triangle-m0z2l"],
-    "images": ["https://raw.githubusercontent.com/react-native-toolkit/react-native-triangle-view/HEAD/assets/logo.png", "https://pbs.twimg.com/profile_images/1268742424517439490/FCYA02Jq_400x400.png"],
+    "examples": [
+      "https://expo.io/@daniakash/TriangleExample",
+      "https://react-native-toolkit.github.io/triangle/",
+      "https://codesandbox.io/s/triangle-m0z2l"
+    ],
+    "images": [
+      "https://raw.githubusercontent.com/react-native-toolkit/react-native-triangle-view/HEAD/assets/logo.png",
+      "https://pbs.twimg.com/profile_images/1268742424517439490/FCYA02Jq_400x400.png"
+    ],
     "ios": true,
     "android": true,
     "web": true,
@@ -5118,20 +5125,15 @@
     "macos": true
   },
   {
-    "githubUrl": "https://github.com/moaazsidat/react-native-qrcode-scanner",
-    "images": ["https://cloud.githubusercontent.com/assets/5963656/25634528/fae4290a-2f48-11e7-899d-4c91ea079678.png"],
-    "ios": true,
-    "android": true,
-    "web": false,
-    "expo": false,
-    "windows": false,
-    "macos": false
-  },
-  {
     "githubUrl": "https://github.com/sospedra/reinput",
     "npmPkg": "reinput",
-    "examples": ["https://github.com/sospedra/reinput/tree/master/example", "https://snack.expo.io/@git/github.com/sospedra/reinput:example"],
-    "images": ["https://user-images.githubusercontent.com/3116899/84693731-3d597380-af48-11ea-8614-b549211f5015.png"],
+    "examples": [
+      "https://github.com/sospedra/reinput/tree/master/example",
+      "https://snack.expo.io/@git/github.com/sospedra/reinput:example"
+    ],
+    "images": [
+      "https://user-images.githubusercontent.com/3116899/84693731-3d597380-af48-11ea-8614-b549211f5015.png"
+    ],
     "ios": true,
     "android": true,
     "web": false,
@@ -5278,6 +5280,9 @@
   },
   {
     "githubUrl": "https://github.com/moaazsidat/react-native-qrcode-scanner",
+    "images": [
+      "https://cloud.githubusercontent.com/assets/5963656/25634528/fae4290a-2f48-11e7-899d-4c91ea079678.png"
+    ],
     "ios": true,
     "android": true,
     "web": false,


### PR DESCRIPTION

# Why

Addresses issue: https://github.com/react-native-directory/website/issues/249

# Changes

- Adds /directory-score route, with a document on how the Directory Score is calculated.
- Adds a link to /directory-score on each library.

# Screenshots

<img width="414" alt="Screen Shot 2020-06-21 at 10 08 40 PM" src="https://user-images.githubusercontent.com/6455018/85242109-14375800-b40c-11ea-8862-af2b15fcd13d.png">
<img width="1594" alt="Screen Shot 2020-06-21 at 10 08 26 PM" src="https://user-images.githubusercontent.com/6455018/85242110-14cfee80-b40c-11ea-816c-6e9541f2dbb6.png">

