### PR TITLE
Use graphql api rate limit and calculate points per request

### DIFF
--- a/scripts/build-and-score-data.js
+++ b/scripts/build-and-score-data.js
@@ -146,7 +146,7 @@ async function loadRepositoryDataAsync() {
     githubResultsFileExists = true;
   } catch (e) {}
 
-  let { apiLimit, apiLimitRemaining } = await fetchGithubRateLimit();
+  let { apiLimit, apiLimitRemaining, apiLimitCost } = await fetchGithubRateLimit();
 
   // 5000 requests per hour is the authenticated API request rate limi
   if (apiLimit < 5000) {
@@ -154,11 +154,13 @@ async function loadRepositoryDataAsync() {
   }
 
   // Error out if not enough remaining
-  if (apiLimitRemaining < data.length) {
+  if (apiLimitRemaining < data.length * apiLimitCost) {
     throw new Error('Not enough requests left on GitHub API rate limiting to proceed.');
   }
 
-  console.info(`${apiLimitRemaining} of ${apiLimit} GitHub API requests remaining for the hour`);
+  console.info(
+    `${apiLimitRemaining} of ${apiLimit} GitHub API requests remaining for the hour at a cost of ${apiLimitCost} per request`
+  );
 
   let result;
   if (LOAD_GITHUB_RESULTS_FROM_DISK && githubResultsFileExists) {


### PR DESCRIPTION
closes #337

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

Uses the correct graphql rate limit endpoint to match the graphql query we make to fetch github info.

It makes a dummy request using actual query as github will return the actual `cost` of the query rather than having to manually calculate it and update it when the query changes.

The query actually only turns out to cost `1` point, and we get `5000` an hour (same as the REST api)

Output
```
  yarn data:update                            
yarn run v1.21.1
$ babel-node scripts/build-and-score-data.js --presets @babel/preset-env
** Loading data from GitHub
4993 of 5000 GitHub API requests remaining for the hour at a cost of 1 per request
```