### PR TITLE
display package license information if provided

### DIFF
--- a/components/Icons/index.tsx
+++ b/components/Icons/index.tsx
@@ -224,6 +224,17 @@ export function Thumbnail({ width = 16, height = 16, fill = colors.gray3 }: Prop
   );
 }
 
+export function License({ width = 16, height = 18, fill = colors.black }: Props) {
+  return (
+    <Svg width={width} height={height} viewBox="0 0 16 18" fill="none">
+      <Path
+        fill={fill}
+        d="M0,0v18h16V0H0z M14,15.9H2V3.1h12C14,3.1,14,15.9,14,15.9z M12,13H4v-1h8V13z M12,10.5H4v-1h8V10.5z M12,8H4V7h8V8z"
+      />
+    </Svg>
+  );
+}
+
 export function Warning({ width = 17, height = 17, fill = colors.warningDark }: Props) {
   return (
     <Svg width={width} height={height} viewBox="0 0 25 25" fill="none">

--- a/components/Library/MetaData.tsx
+++ b/components/Library/MetaData.tsx
@@ -56,13 +56,6 @@ export function MetaData(props: Props) {
           ),
         }
       : null,
-    library.github.urls.homepage
-      ? {
-          id: 'web',
-          icon: <Web fill={colors.gray5} />,
-          content: <A href={library.github.urls.homepage}>Visit Website</A>,
-        }
-      : null,
     library.github.license
       ? {
           id: 'license',
@@ -73,6 +66,13 @@ export function MetaData(props: Props) {
             ) : (
               <A href={library.github.license.url}>{library.github.license.name}</A>
             ),
+        }
+      : null,
+    library.github.urls.homepage
+      ? {
+          id: 'web',
+          icon: <Web fill={colors.gray5} />,
+          content: <A href={library.github.urls.homepage}>Visit Website</A>,
         }
       : null,
   ].filter(Boolean);

--- a/components/Library/MetaData.tsx
+++ b/components/Library/MetaData.tsx
@@ -69,7 +69,7 @@ export function MetaData(props: Props) {
           icon: <License fill={colors.gray5} />,
           content:
             library.github.license.name === 'Other' ? (
-              <P>{library.github.license.name}</P>
+              <P>Unrecognized License</P>
             ) : (
               <A href={library.github.license.url}>{library.github.license.name}</A>
             ),

--- a/components/Library/MetaData.tsx
+++ b/components/Library/MetaData.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import { colors, A, Caption } from '../../common/styleguide';
+import { colors, A, P, Caption } from '../../common/styleguide';
 import { Library as LibraryType } from '../../types';
 import { getTimeSinceToday } from '../../util/datetime';
-import { Calendar, Star, Download, Issue, Web } from '../Icons';
+import { Calendar, Star, Download, Issue, Web, License } from '../Icons';
 import { DirectoryScore } from './DirectoryScore';
 
 type Props = {
@@ -61,6 +61,18 @@ export function MetaData(props: Props) {
           id: 'web',
           icon: <Web fill={colors.gray5} />,
           content: <A href={library.github.urls.homepage}>Visit Website</A>,
+        }
+      : null,
+    library.github.license
+      ? {
+          id: 'license',
+          icon: <License fill={colors.gray5} />,
+          content:
+            library.github.license.name === 'Other' ? (
+              <P>{library.github.license.name}</P>
+            ) : (
+              <A href={library.github.license.url}>{library.github.license.name}</A>
+            ),
         }
       : null,
   ].filter(Boolean);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

This PR adds licence row to the `MetaData` column. Since the license information is included in the directory score calculation it would be nice to display it. It's also a common information displayed for the GitHub repositories and NPM packages.

I have created the simple icon myself, it can be clanged in any way you like. For example GitHub uses scale weight icon for license. Also I'm not sure about the best placement so I have put this row at the end for now.

### Preview
<img width="906" alt="Annotation 2020-06-24 192006" src="https://user-images.githubusercontent.com/719641/85604246-6a490d00-b651-11ea-9957-c6b1e3611a2b.png">

# Checklist

<!--
Check completed item, when applicable, via: [X]
-->

If you added a new library:

- [ ] Added it to **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.
