### PR TITLE
fix: Monorepo license issue by parsing package.json

### DIFF
--- a/debug-github-repos.json
+++ b/debug-github-repos.json
@@ -4,6 +4,10 @@
     "expo": true
   },
   { "githubUrl": "https://github.com/gre/gl-react", "expo": true },
+  {
+    "githubUrl": "https://github.com/expo/expo/tree/master/packages/expo-barcode-scanner",
+    "expo": true
+  },
   { "githubUrl": "https://github.com/n4kz/react-native-pages", "expo": true },
   { "githubUrl": "https://github.com/airbnb/lottie-react-native", "expo": true }
 ]

--- a/scripts/build-and-score-data.js
+++ b/scripts/build-and-score-data.js
@@ -7,7 +7,7 @@ import debugGithubRepos from '../debug-github-repos.json';
 import githubRepos from '../react-native-libraries.json';
 import * as Strings from '../util/strings';
 import calculateScore from './calculate-score';
-import { fetchGithubData, fetchGithubRateLimit } from './fetch-github-data';
+import { fetchGithubData, fetchGithubRateLimit, loadGitHubLicenses } from './fetch-github-data';
 import fetchNpmData from './fetch-npm-data';
 import fetchReadmeImages from './fetch-readme-images';
 
@@ -160,6 +160,8 @@ async function loadRepositoryDataAsync() {
   console.info(
     `${apiLimitRemaining} of ${apiLimit} GitHub API requests remaining for the hour at a cost of ${apiLimitCost} per request`
   );
+
+  await loadGitHubLicenses();
 
   let result;
   if (LOAD_GITHUB_RESULTS_FROM_DISK && githubResultsFileExists) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

Monorepos had a bug meaning licenses weren't used from the package.json. They also would have had the wrong format.

This change parses the package.json to get the license for monorepos and then replaces it with the github license scheme to match the others.

![image](https://user-images.githubusercontent.com/5689874/85617775-b26b2e00-b657-11ea-9a72-a62b2f43578e.png)


# Checklist



If you added a feature or fixed a bug:

- [x] Documented in this PR how to use the feature or replicate the bug.
- [x] Documented in this PR how you fixed or created the feature.
