### PR TITLE
subtract Directory Score points also for unrecognized license

### DIFF
--- a/pages/directory-score.tsx
+++ b/pages/directory-score.tsx
@@ -54,7 +54,9 @@ function DirectoryScore(props) {
       </P>
       <Headline style={styles.criterion}>Lots of open issues (-20)</Headline>
       <P style={styles.paragraph}>Libraries with more than 75 open issues meet this criterion.</P>
-      <Headline style={styles.criterion}>No license or GPL license (-20)</Headline>
+      <Headline style={styles.criterion}>
+        No license, unrecognized license or GPL license (-20)
+      </Headline>
       <P style={styles.paragraph}>
         Libraries without a license or that include the GPL license meet this criterion.
       </P>

--- a/pages/directory-score.tsx
+++ b/pages/directory-score.tsx
@@ -58,7 +58,8 @@ function DirectoryScore(props) {
         No license, unrecognized license or GPL license (-20)
       </Headline>
       <P style={styles.paragraph}>
-        Libraries without a license or that include the GPL license meet this criterion.
+        Libraries without a license, libraries with non-standard license or that include the GPL
+        license meet this criterion.
       </P>
     </ContentContainer>
   );

--- a/scripts/calculate-score.js
+++ b/scripts/calculate-score.js
@@ -35,7 +35,10 @@ const modifiers = [
   {
     name: 'GPL license',
     value: -20,
-    condition: data => data.license && data.license.key && data.license.key.startsWith('gpl'),
+    condition: data =>
+      data.license &&
+      data.license.key &&
+      (data.license.key.startsWith('gpl') || data.license.key.startsWith('other')),
   },
   {
     name: 'Recently updated',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

Refs #340 

Currently the Directory Score for the package with unrecognized license (`"Other"` license) was unmodified. This PR fixes this issue and updates the score explanation on the Directory Score page.

# Checklist

<!--
Check completed item, when applicable, via: [X]
-->

If you added a new library:

- [ ] Added it to **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.
