### PR TITLE
add "Maintained" filter

### DIFF
--- a/components/Filters.tsx
+++ b/components/Filters.tsx
@@ -113,6 +113,12 @@ export const Filters = (props: FiltersProps) => {
           ))}
         </View>
       </View>
+      <View style={styles.container}>
+        <Headline style={styles.title}>Status</Headline>
+        <View style={styles.optionsContainer}>
+          <ToggleLink key="maintained" query={query} paramName="maintained" title="Maintained" />
+        </View>
+      </View>
     </View>
   );
 };
@@ -120,12 +126,14 @@ export const Filters = (props: FiltersProps) => {
 const styles = StyleSheet.create({
   wrapper: {
     backgroundColor: colors.gray1,
+    paddingVertical: 8,
     flex: 1,
     alignItems: 'center',
   },
   container: {
     width: '100%',
-    padding: 16,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
     maxWidth: layout.maxWidth,
   },
   optionsContainer: {

--- a/components/Filters.tsx
+++ b/components/Filters.tsx
@@ -70,9 +70,9 @@ function ToggleLink({ query, paramName, title }) {
 
 export const FilterButton = (props: FilterButtonProps) => {
   const { isFilterVisible, query, onPress } = props;
-  const platformParams = platforms.map(platform => platform.param);
+  const params = [...platforms.map(platform => platform.param), 'maintained'];
   const filterCount = Object.keys(query).reduce(
-    (acc, q) => (platformParams.includes(q) ? acc + 1 : acc),
+    (acc, q) => (params.includes(q) ? acc + 1 : acc),
     0
   );
 
@@ -149,7 +149,6 @@ const styles = StyleSheet.create({
         cursor: 'pointer',
       },
     }),
-    fontSize: 14,
     marginRight: 16,
     marginVertical: 4,
     alignItems: 'center',

--- a/pages/api/libraries/index.ts
+++ b/pages/api/libraries/index.ts
@@ -51,6 +51,7 @@ function handler(req: NextApiRequest, res: NextApiResponse) {
       macos: req.query.macos,
       expo: req.query.expo,
     },
+    maintained: req.query.maintained,
   });
 
   let offset = req.query.offset ? parseInt(req.query.offset.toString(), 10) : 0;

--- a/util/search.js
+++ b/util/search.js
@@ -1,10 +1,16 @@
 import { isEmptyOrNull } from './strings';
 
-export const handleFilterLibraries = ({ libraries, queryTopic, querySearch, support }) => {
+export const handleFilterLibraries = ({
+  libraries,
+  queryTopic,
+  querySearch,
+  support,
+  maintained,
+}) => {
   const viewerHasChosenTopic = !isEmptyOrNull(queryTopic);
   const viewerHasTypedSearch = !isEmptyOrNull(querySearch);
 
-  let filtered = libraries.filter(library => {
+  return libraries.filter(library => {
     let isTopicMatch = false;
     let isSearchMatch = false;
 
@@ -33,6 +39,10 @@ export const handleFilterLibraries = ({ libraries, queryTopic, querySearch, supp
     }
 
     if (support.expo && typeof library.expo === 'string') {
+      return false;
+    }
+
+    if (maintained && library.unmaintained) {
       return false;
     }
 
@@ -69,6 +79,4 @@ export const handleFilterLibraries = ({ libraries, queryTopic, querySearch, supp
 
     return isTopicMatch && isSearchMatch;
   });
-
-  return filtered;
 };


### PR DESCRIPTION
# Why

This PR introduces another group of filters - Status - and the first filter in this group which allows to hide libraries with `unmaintained` value set to `true`. I think that this new feature will be useful and besides that I have few other ideas related to the new filters in this group.

I'm not sure about naming, in the initial version I have used the `Hide unmaintained` label (because it was more obvious that when checkbox is not selected the results are not affected).

### Preview
<img width="914" alt="Annotation 2020-06-25 152612" src="https://user-images.githubusercontent.com/719641/85728474-3ecd2d80-b6f8-11ea-813a-b883dbcb153f.png">

# Checklist

- [X] Documented in this PR how you fixed or created the feature.
