### PR TITLE
update moved packages GitHub URLs

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1627,7 +1627,7 @@
     "android": true
   },
   {
-    "githubUrl": "https://github.com/mvayngrib/rn-nodeify",
+    "githubUrl": "https://github.com/tradle/rn-nodeify",
     "ios": true,
     "android": true
   },
@@ -5310,7 +5310,7 @@
     "unmaintained": false
   },
   {
-    "githubUrl": "https://github.com/mvayngrib/react-native-crypto",
+    "githubUrl": "https://github.com/tradle/react-native-crypto",
     "ios": true,
     "android": true,
     "web": false,


### PR DESCRIPTION
# Why

During the work on description linkify I have spotted that two packages has been moved. This PR fixes the GitHub URLs for those packages.

# Checklist

- [X] Updated **react-native-libraries.json**
