### PR TITLE
add few more status filters

### DIFF
--- a/components/Filters.tsx
+++ b/components/Filters.tsx
@@ -70,7 +70,15 @@ function ToggleLink({ query, paramName, title }) {
 
 export const FilterButton = (props: FilterButtonProps) => {
   const { isFilterVisible, query, onPress } = props;
-  const params = [...platforms.map(platform => platform.param), 'maintained'];
+  const params = [
+    ...platforms.map(platform => platform.param),
+    'hasExample',
+    'hasImage',
+    'isMaintained',
+    'isPopular',
+    'isRecommended',
+    'wasRecentlyUpdated',
+  ];
   const filterCount = Object.keys(query).reduce(
     (acc, q) => (params.includes(q) ? acc + 1 : acc),
     0
@@ -116,7 +124,27 @@ export const Filters = (props: FiltersProps) => {
       <View style={styles.container}>
         <Headline style={styles.title}>Status</Headline>
         <View style={styles.optionsContainer}>
-          <ToggleLink key="maintained" query={query} paramName="maintained" title="Maintained" />
+          <ToggleLink key="hasExample" query={query} paramName="hasExample" title="Has example" />
+          <ToggleLink key="hasImage" query={query} paramName="hasImage" title="Has image preview" />
+          <ToggleLink
+            key="isMaintained"
+            query={query}
+            paramName="isMaintained"
+            title="Maintained"
+          />
+          <ToggleLink key="isPopular" query={query} paramName="isPopular" title="Popular" />
+          <ToggleLink
+            key="wasRecentlyUpdated"
+            query={query}
+            paramName="wasRecentlyUpdated"
+            title="Recently updated"
+          />
+          <ToggleLink
+            key="isRecommended"
+            query={query}
+            paramName="isRecommended"
+            title="Recommended"
+          />
         </View>
       </View>
     </View>

--- a/pages/api/libraries/index.ts
+++ b/pages/api/libraries/index.ts
@@ -51,7 +51,12 @@ function handler(req: NextApiRequest, res: NextApiResponse) {
       macos: req.query.macos,
       expo: req.query.expo,
     },
-    maintained: req.query.maintained,
+    hasExample: req.query.hasExample,
+    hasImage: req.query.hasImage,
+    isMaintained: req.query.isMaintained,
+    isPopular: req.query.isPopular,
+    isRecommended: req.query.isRecommended,
+    wasRecentlyUpdated: req.query.wasRecentlyUpdated,
   });
 
   let offset = req.query.offset ? parseInt(req.query.offset.toString(), 10) : 0;

--- a/util/search.js
+++ b/util/search.js
@@ -5,7 +5,12 @@ export const handleFilterLibraries = ({
   queryTopic,
   querySearch,
   support,
-  maintained,
+  hasExample,
+  hasImage,
+  isMaintained,
+  isPopular,
+  isRecommended,
+  wasRecentlyUpdated,
 }) => {
   const viewerHasChosenTopic = !isEmptyOrNull(queryTopic);
   const viewerHasTypedSearch = !isEmptyOrNull(querySearch);
@@ -42,7 +47,27 @@ export const handleFilterLibraries = ({
       return false;
     }
 
-    if (maintained && library.unmaintained) {
+    if (hasExample && (!library.examples || !library.examples.length)) {
+      return false;
+    }
+
+    if (hasImage && (!library.images || !library.images.length)) {
+      return false;
+    }
+
+    if (isMaintained && library.unmaintained) {
+      return false;
+    }
+
+    if (isPopular && !library.matchingScoreModifiers.includes('Popular')) {
+      return false;
+    }
+
+    if (isRecommended && !library.matchingScoreModifiers.includes('Recommended')) {
+      return false;
+    }
+
+    if (wasRecentlyUpdated && !library.matchingScoreModifiers.includes('Recently updated')) {
       return false;
     }
 


### PR DESCRIPTION
# Why

Refs #347

This PR adds few more status filters based on data which might be interesting for the users. I have currently added the following filters, but I'm open to add or remove some (labels also can be adjusted):
- `hasExample` - based on the `examples` array
- `hasImage` - based on the `images` array
- `isPopular` - based on the `matchingScoreModifiers`
- `isRecommended` - based on the `matchingScoreModifiers`
- `wasRecentlyUpdated` - based on the `matchingScoreModifiers`

I have also renamed `maintained` to `isMaintained` to suggest type in the filter name.

### Preview
<img width="958" alt="Annotation 2020-06-25 233904" src="https://user-images.githubusercontent.com/719641/85798795-6ba43380-b73e-11ea-94db-1e9a023ca38e.png">

# Checklist

- [X] Documented in this PR how you fixed or created the feature.
