### PR TITLE
add react-native-dynamic

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3808,7 +3808,7 @@
     "ios": true,
     "android": true,
     "npmPkg": "react-native-dark-mode",
-    "unmaintained": false
+    "unmaintained": true
   },
   {
     "githubUrl": "https://github.com/DylanVann/react-native-fast-image",
@@ -5607,6 +5607,17 @@
     "expo": true,
     "windows": false,
     "macos": false,
+    "unmaintained": false
+  },
+  {
+    "githubUrl": "https://github.com/codemotionapps/react-native-dynamic",
+    "examples": ["https://github.com/codemotionapps/react-native-dynamic/tree/master/example"],
+    "images": [
+      "https://raw.githubusercontent.com/codemotionapps/react-native-dynamic/master/showcase.ios.gif"
+      "https://raw.githubusercontent.com/codemotionapps/react-native-dynamic/master/showcase.android.gif"
+    ],
+    "ios": true,
+    "android": true,
     "unmaintained": false
   }
 ]

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -5613,7 +5613,7 @@
     "githubUrl": "https://github.com/codemotionapps/react-native-dynamic",
     "examples": ["https://github.com/codemotionapps/react-native-dynamic/tree/master/example"],
     "images": [
-      "https://raw.githubusercontent.com/codemotionapps/react-native-dynamic/master/showcase.ios.gif"
+      "https://raw.githubusercontent.com/codemotionapps/react-native-dynamic/master/showcase.ios.gif",
       "https://raw.githubusercontent.com/codemotionapps/react-native-dynamic/master/showcase.android.gif"
     ],
     "ios": true,


### PR DESCRIPTION
# Why

This PR adds `react-native-dynamic` which is a replacement for the `react-native-dark-mode` by the same authors/organization. 

Also  `react-native-dark-mode` has been marked as unmaintained.

# Checklist

- [X] Added it to **react-native-libraries.json**
