### PR TITLE
add react-native-copilot library

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -5639,5 +5639,19 @@
     "windows": false,
     "macos": false,
     "unmaintained": false
+  },
+  {
+    "githubUrl": "https://github.com/mohebifar/react-native-copilot",
+    "examples": [
+      "https://expo.io/@mohebifar/copilot-example",
+      "https://github.com/mohebifar/react-native-copilot/tree/master/example"
+    ],
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": true,
+    "windows": false,
+    "macos": false,
+    "unmaintained": false
   }
 ]


### PR DESCRIPTION
# Why

This PR adds `react-native-copilot` library to the directory.

# Checklist

If you added a new library:

- [X] Added it to **react-native-libraries.json**
