### PR TITLE
Design Updates - move secondary meta inside library box, add forks, improve thumbnails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,41 +6,37 @@ secrets.json
 # Standard stuff
 yarn-error.log
 node_modules/**/*
-.expo/*
 npm-debug.*
-*.jks
-*.p8
-*.p12
-*.key
-*.mobileprovision
-*.orig.*
-web-build/
-web-report/
 
 # macOS
 .DS_Store
 
-# @generated: @expo/next-adapter@2.0.4
-/.expo/*
 # Expo Web
-/web-build/*
-/web-report/*
+web-build
+web-report
+
 # Expo Native
+.expo
 *.jks
 *.p8
 *.p12
 *.key
 *.mobileprovision
 *.orig.*
-# Next.js
-/.next/*
-/out/
-# Next.js production
-/build/
-# Next.js dependencies
-/.pnp
-.pnp.js
-# @end @expo/next-adapter
 
+# Next.js
+.next/*
+out/
+
+# Next.js production
+build/
+
+# Next.js dependencies
+.pnp
+.pnp.js
+
+# Now.js
 .now
+
+# IDEs
 .idea

--- a/common/styleguide.tsx
+++ b/common/styleguide.tsx
@@ -59,7 +59,7 @@ type TextProps = {
   ref?: RefObject<ReactNode>;
 };
 
-function createTextComponent(Element: any, textStyle?: TextStyle) {
+function createTextComponent(Element: any, textStyle?: TextStyle | TextStyle[]) {
   return (props: TextProps) => {
     const { children, style } = props;
     return <Element style={[textStyles[Element], textStyle, style]}>{children}</Element>;
@@ -78,7 +78,7 @@ export const Caption = createTextComponent(HtmlElements.P, textStyles.caption);
 export const Label = createTextComponent(HtmlElements.P, textStyles.label);
 
 type AProps = {
-  style?: TextStyle;
+  style?: TextStyle | TextStyle[];
   target?: string;
   href: string;
   children?: ReactNode;

--- a/components/Icons/index.tsx
+++ b/components/Icons/index.tsx
@@ -235,6 +235,21 @@ export function License({ width = 16, height = 18, fill = colors.black }: Props)
   );
 }
 
+export function Fork({ width = 15, height = 16, fill = colors.black }: Props) {
+  return (
+    <Svg width={width} height={height} viewBox="0 0 15 16" fill="none">
+      <Path
+        fill={fill}
+        d="M8.5,10.8V8l4.7-5l0,2.3H15V0H9.7v1.8H12L7.5,6.5L3,1.8h2.3V0H0v5.3h1.8V3l4.7,5v2.9"
+      />
+      <Path
+        fill={fill}
+        d="M10.7,12.8c0,1.8-1.4,3.2-3.2,3.2s-3.2-1.4-3.2-3.2s1.4-3.2,3.2-3.2S10.7,11.1,10.7,12.8z M7.5,11.4c-0.8,0-1.4,0.6-1.4,1.4s0.6,1.4,1.4,1.4s1.4-0.6,1.4-1.4S8.3,11.4,7.5,11.4z"
+      />
+    </Svg>
+  );
+}
+
 export function Warning({ width = 17, height = 17, fill = colors.warningDark }: Props) {
   return (
     <Svg width={width} height={height} viewBox="0 0 25 25" fill="none">

--- a/components/Library/MetaData.tsx
+++ b/components/Library/MetaData.tsx
@@ -4,90 +4,118 @@ import { StyleSheet, View } from 'react-native';
 import { colors, A, P, Caption } from '../../common/styleguide';
 import { Library as LibraryType } from '../../types';
 import { getTimeSinceToday } from '../../util/datetime';
-import { Calendar, Star, Download, Issue, Web, License } from '../Icons';
+import { Calendar, Star, Download, Issue, Web, License, Fork } from '../Icons';
 import { DirectoryScore } from './DirectoryScore';
 
 type Props = {
   library: LibraryType;
+  secondary?: boolean;
 };
 
 export function MetaData(props: Props) {
-  const { library } = props;
+  const { library, secondary } = props;
+  const { github } = library;
 
-  const data = [
-    {
-      id: 'score',
-      icon: <DirectoryScore score={library.score} />,
-      content: (
-        <A target="" href="/directory-score" style={styles.directoryScoreLink}>
-          Directory Score
-        </A>
-      ),
-    },
-    {
-      id: 'calendar',
-      icon: <Calendar fill={colors.gray5} />,
-      content: `Updated ${getTimeSinceToday(library.github.stats.pushedAt)}`,
-    },
-    {
-      id: 'star',
-      icon: <Star fill={colors.gray5} />,
-      content: `${library.github.stats.stars.toLocaleString()} stars`,
-    },
-    library.npm.downloads
-      ? {
-          id: 'downloads',
-          icon: <Download fill={colors.gray5} />,
+  const data = secondary
+    ? [
+        github.urls.homepage
+          ? {
+              id: 'web',
+              icon: <Web fill="#afb1af" width={16} height={16} />,
+              content: (
+                <A href={github.urls.homepage} style={[styles.mutedLink, styles.secondaryText]}>
+                  Website
+                </A>
+              ),
+            }
+          : null,
+        github.license
+          ? {
+              id: 'license',
+              icon: <License fill="#afb1af" width={14} height={16} />,
+              content:
+                github.license.name === 'Other' ? (
+                  <P style={styles.secondaryText}>Unrecognized License</P>
+                ) : (
+                  <A href={github.license.url} style={[styles.mutedLink, styles.secondaryText]}>
+                    {github.license.name}
+                  </A>
+                ),
+            }
+          : null,
+      ]
+    : [
+        {
+          id: 'score',
+          icon: <DirectoryScore score={library.score} />,
           content: (
-            <A href={`https://www.npmjs.com/package/${library.npmPkg}`}>
-              {`${library.npm.downloads.toLocaleString()}`} {library.npm.period}ly downloads
+            <A target="" href="/directory-score" style={styles.mutedLink}>
+              Directory Score
             </A>
           ),
-        }
-      : null,
-    library.github.stats.issues
-      ? {
-          id: 'issues',
-          icon: <Issue fill={colors.gray5} />,
-          content: (
-            <A href={`${library.github.urls.repo}/issues`}>
-              {`${library.github.stats.issues.toLocaleString()}`} issues
-            </A>
-          ),
-        }
-      : null,
-    library.github.license
-      ? {
-          id: 'license',
-          icon: <License fill={colors.gray5} />,
-          content:
-            library.github.license.name === 'Other' ? (
-              <P>Unrecognized License</P>
-            ) : (
-              <A href={library.github.license.url}>{library.github.license.name}</A>
-            ),
-        }
-      : null,
-    library.github.urls.homepage
-      ? {
-          id: 'web',
-          icon: <Web fill={colors.gray5} />,
-          content: <A href={library.github.urls.homepage}>Visit Website</A>,
-        }
-      : null,
-  ].filter(Boolean);
+        },
+        {
+          id: 'calendar',
+          icon: <Calendar fill={colors.gray5} />,
+          content: `Updated ${getTimeSinceToday(github.stats.pushedAt)}`,
+        },
+        library.npm.downloads
+          ? {
+              id: 'downloads',
+              icon: <Download fill={colors.gray5} />,
+              content: (
+                <A href={`https://www.npmjs.com/package/${library.npmPkg}`}>
+                  {`${library.npm.downloads.toLocaleString()}`} {library.npm.period}ly downloads
+                </A>
+              ),
+            }
+          : null,
+        {
+          id: 'star',
+          icon: <Star fill={colors.gray5} />,
+          content: `${github.stats.stars.toLocaleString()} stars`,
+        },
+        github.stats.forks
+          ? {
+              id: 'forks',
+              icon: <Fork fill={colors.gray5} width={16} height={17} />,
+              content: (
+                <A href={`${github.urls.repo}/network/members`}>
+                  {`${github.stats.forks.toLocaleString()}`} forks
+                </A>
+              ),
+            }
+          : null,
+        github.stats.issues
+          ? {
+              id: 'issues',
+              icon: <Issue fill={colors.gray5} />,
+              content: (
+                <A href={`${github.urls.repo}/issues`}>
+                  {`${github.stats.issues.toLocaleString()}`} issues
+                </A>
+              ),
+            }
+          : null,
+      ];
 
   return (
-    <View>
-      {data.map((datum, i) => (
+    <>
+      {data.filter(Boolean).map((datum, i) => (
         <View
           key={datum.id}
-          style={[styles.displayHorizontal, i + 1 !== data.length ? styles.datumContainer : {}]}>
-          <View style={styles.iconContainer}>{datum.icon}</View>
+          style={[
+            styles.displayHorizontal,
+            i + 1 !== data.length ? styles.datumContainer : {},
+            secondary ? styles.secondaryContainer : {},
+          ]}>
+          <View style={[styles.iconContainer, secondary ? styles.secondaryIconContainer : {}]}>
+            {datum.icon}
+          </View>
           <Caption>{datum.content}</Caption>
         </View>
       ))}
-    </View>
+    </>
   );
 }
 
@@ -104,7 +132,18 @@ const styles = StyleSheet.create({
     width: 20,
     alignItems: 'center',
   },
-  directoryScoreLink: {
+  mutedLink: {
     backgroundColor: 'transparent',
+  },
+  secondaryText: {
+    fontSize: 13,
+    color: colors.gray5,
+  },
+  secondaryContainer: {
+    marginBottom: 0,
+    marginRight: 16,
+  },
+  secondaryIconContainer: {
+    marginRight: 6,
   },
 });

--- a/components/Library/Thumbnail.tsx
+++ b/components/Library/Thumbnail.tsx
@@ -29,9 +29,23 @@ const Thumbnail = ({ url }: Props) => {
     <>
       <a
         ref={iconRef}
-        onMouseOver={handleMouseEvent}
-        onMouseOut={handleMouseEvent}
-        style={{ marginRight: 15, marginBottom: 8 }}>
+        onMouseEnter={handleMouseEvent}
+        onMouseLeave={handleMouseEvent}
+        style={{
+          marginRight: 10,
+          marginTop: 4,
+          marginBottom: 4,
+          padding: 6,
+          paddingBottom: 0,
+          minHeight: 30,
+          boxSizing: 'border-box',
+          overflow: 'hidden',
+          textAlign: 'center',
+          borderWidth: 1,
+          borderRadius: 3,
+          borderColor: colors.gray2,
+          borderStyle: 'solid',
+        }}>
         <ThumbnailIcon fill={showPreview ? colors.primary : undefined} />
       </a>
       {createPortal(

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -21,6 +21,16 @@ export default function Library(props: Props) {
   return (
     <View style={[styles.container, layout.isSmallScreen() && styles.containerColumn]}>
       <View style={styles.columnOne}>
+        {library.unmaintained ? (
+          <View style={styles.unmaintainedTextWrapper}>
+            <View style={styles.unmaintainedTextContainer}>
+              <Warning width={16} height={16} />
+              <Label style={styles.unmaintainedText}>
+                This library is not actively maintained!
+              </Label>
+            </View>
+          </View>
+        ) : null}
         <View style={styles.displayHorizontal}>
           <A
             href={library.githubUrl || library.github.urls.repo}
@@ -37,16 +47,6 @@ export default function Library(props: Props) {
             </View>
           )}
         </View>
-        {library.unmaintained ? (
-          <View style={styles.unmaintainedTextWrapper}>
-            <View style={styles.unmaintainedTextContainer}>
-              <Warning width={16} height={16} />
-              <Label style={styles.unmaintainedText}>
-                This library is not actively maintained!
-              </Label>
-            </View>
-          </View>
-        ) : null}
         <View style={styles.verticalMargin}>
           <CompatibilityTags library={library} />
         </View>
@@ -76,6 +76,16 @@ export default function Library(props: Props) {
             ))}
           </View>
         ) : null}
+        {library.github.license || library.github.urls.homepage ? (
+          <>
+            <View style={styles.filler} />
+            <View style={styles.bottomBar}>
+              <View style={[styles.displayHorizontal, styles.secondaryStats]}>
+                <MetaData library={library} secondary />
+              </View>
+            </View>
+          </>
+        ) : null}
       </View>
       <View style={[styles.columnTwo, layout.isSmallScreen() && styles.columnTwoSmall]}>
         <MetaData library={library} />
@@ -91,6 +101,7 @@ let styles = StyleSheet.create({
     marginBottom: 16,
     borderRadius: 4,
     flexDirection: 'row',
+    overflow: 'hidden',
   },
   containerColumn: {
     flexDirection: 'column',
@@ -102,6 +113,7 @@ let styles = StyleSheet.create({
       },
     }),
     padding: 16,
+    paddingLeft: 20,
   },
   columnTwo: {
     ...Platform.select({
@@ -110,6 +122,7 @@ let styles = StyleSheet.create({
       },
     }),
     padding: 16,
+    paddingLeft: 18,
     borderLeftWidth: 1,
     borderLeftColor: colors.gray2,
   },
@@ -155,11 +168,10 @@ let styles = StyleSheet.create({
   unmaintainedTextContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginTop: 8,
-    marginLeft: -16,
-    marginBottom: 2,
+    marginLeft: -20,
+    marginBottom: 12,
     backgroundColor: colors.warningLight,
-    paddingLeft: 16,
+    paddingLeft: 20,
     paddingRight: 12,
     paddingVertical: 6,
     borderRadius: 2,
@@ -173,8 +185,28 @@ let styles = StyleSheet.create({
   },
   imagesContainer: {
     flexWrap: 'wrap',
-    marginTop: 20,
-    marginBottom: 12,
-    marginLeft: 2,
+    marginTop: 12,
+  },
+  secondaryStats: {
+    marginTop: 6,
+    flexWrap: 'wrap',
+  },
+  secondaryText: {
+    fontSize: 13,
+    color: colors.gray5,
+  },
+  bottomBar: {
+    width: '100%',
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    minHeight: 42,
+    borderTopColor: colors.gray2,
+    paddingLeft: 20,
+    paddingRight: 16,
+  },
+  filler: {
+    flex: 1,
+    paddingBottom: 34,
   },
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

The main goal introducing those changes was to attempt to utilize empty spaces in the library box a bit more. There were a lot of iterations and ideas when I was working on the change set, but I hope it was worth (and improve UX for the directory users).

The following changes has been made:
* website and license (non numeric) MetaData has been moved to the library box and sicked to the bottom - other data can be added here in the future
* forks count added (we already have this information and it's a part of scoring criterion)
* thumbnails design updated (do differentiate them a bit more form the plain. non-functional icons) and portal flickering on hover fixed
* unmaintained label moved to the to of library box (above the name)
* fix styleguide types error when array of styles has been provided instead of object
* `.gitignore` cleanup

### Preview

<img width="970" alt="Annotation 2020-07-08 112232" src="https://user-images.githubusercontent.com/719641/86901789-60251500-c10d-11ea-9e0a-a8cffb6e2cb6.png">

#### Mobile layout
<img width="324" alt="Annotation 2020-07-08 113231" src="https://user-images.githubusercontent.com/719641/86902823-c5c5d100-c10e-11ea-9881-b3942a8b23f0.png">


# Checklist

If you added a feature or fixed a bug:

- [X] Documented in this PR how you fixed or created the feature.
