### PR TITLE
read missing description and topics from package.json

### DIFF
--- a/scripts/build-and-score-data.js
+++ b/scripts/build-and-score-data.js
@@ -80,7 +80,7 @@ const buildAndScoreData = async () => {
       });
     }
 
-    projectList[index].topicSearchString = topicSearchString;
+    projectList[index].topicSearchString = topicSearchString.trim();
   });
 
   if (invalidRepos.length) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

This PR adds fallback read of description and topics fields from `package.json` to the data fetching script (for regular and monorepo packages) and trims the `topicSearchString` value.

### Examples
#### `react-native-digits`
<img width="416" alt="Annotation 2020-07-11 132233" src="https://user-images.githubusercontent.com/719641/87223628-d2e8f700-c37e-11ea-8c90-ba3dad86fd10.png">

#### `react-native-conductor`
<img width="500" alt="Annotation 2020-07-11 140335" src="https://user-images.githubusercontent.com/719641/87223707-573b7a00-c37f-11ea-9e20-9a8099bcb93a.png">

#### `@expo/react-native-action-sheet`
<img width="428" alt="Annotation 2020-07-11 140840" src="https://user-images.githubusercontent.com/719641/87223785-0d06c880-c380-11ea-9ded-b7096d594971.png">


# Checklist

If you added a feature or fixed a bug:

- [X] Documented in this PR how you fixed or created the feature.
