### PR TITLE
add max height to the image preview 

### DIFF
--- a/styles/PreviewStyles.tsx
+++ b/styles/PreviewStyles.tsx
@@ -20,11 +20,13 @@ const PreviewStyles = () => {
         box-sizing: border-box;
         box-shadow: 0 5px 5px 0px #00000025 !important;
         max-width: ${previewWidth}px;
+        max-height: 66vh;
       }
 
       .preview img {
         display: none;
         max-width: ${previewImageWidth}px;
+        max-height: calc(66vh - 20px);
       }
 
       .preview.loaded img {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

This small PR adds `max-height` attribute to the image preview and it's container set based on viewport height. I have set the height limit to the 66% of that height, but I can change that value in any way you think it's more suitable.

The goal was to prevent the image clipping like on the example screenshot below.

# Preview
<img width="1083" alt="height" src="https://user-images.githubusercontent.com/719641/87229896-58cf6700-c3ac-11ea-9681-41ded7855680.png">

# Checklist

If you added a feature or fixed a bug:

- [X] Documented in this PR how you fixed or created the feature.
