### PR TITLE
move examples list to the bottom MetaData bar

### DIFF
--- a/components/Icons/index.tsx
+++ b/components/Icons/index.tsx
@@ -250,6 +250,16 @@ export function Fork({ width = 15, height = 16, fill = colors.black }: Props) {
   );
 }
 
+export function Code({ width = 16, height = 16, fill = colors.black }: Props) {
+  return (
+    <Svg width={width} height={height} viewBox="0 0 16 16" fill="none">
+      <Path fill={fill} d="M0,8l5-3.2v2L2.8,8L5,9.3v2L0,8z" />
+      <Path fill={fill} d="M13.2,8L11,6.7v-2L16,8l-5,3.3v-2L13.2,8z" />
+      <Path fill={fill} d="M7.3,13.8H5.8l3-11.5h1.5L7.3,13.8z" />
+    </Svg>
+  );
+}
+
 export function Warning({ width = 17, height = 17, fill = colors.warningDark }: Props) {
   return (
     <Svg width={width} height={height} viewBox="0 0 25 25" fill="none">

--- a/components/Library/MetaData.tsx
+++ b/components/Library/MetaData.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, View } from 'react-native';
 import { colors, A, P, Caption } from '../../common/styleguide';
 import { Library as LibraryType } from '../../types';
 import { getTimeSinceToday } from '../../util/datetime';
-import { Calendar, Star, Download, Issue, Web, License, Fork } from '../Icons';
+import { Calendar, Star, Download, Issue, Web, License, Fork, Code } from '../Icons';
 import { DirectoryScore } from './DirectoryScore';
 
 type Props = {
@@ -41,6 +41,26 @@ export function MetaData(props: Props) {
                     {github.license.name}
                   </A>
                 ),
+            }
+          : null,
+        library.examples && library.examples.length
+          ? {
+              id: 'examples',
+              icon: <Code fill="#afb1af" width={16} height={16} />,
+              content: (
+                <>
+                  <Caption style={styles.secondaryText}>Examples: </Caption>
+                  {library.examples.map((example, index) => (
+                    <A
+                      key={example}
+                      href={example}
+                      target="blank"
+                      style={[styles.mutedLink, styles.secondaryText, styles.exampleLink]}>
+                      #{index + 1}
+                    </A>
+                  ))}
+                </>
+              ),
             }
           : null,
       ]
@@ -145,5 +165,9 @@ const styles = StyleSheet.create({
   },
   secondaryIconContainer: {
     marginRight: 6,
+  },
+  exampleLink: {
+    marginLeft: 2,
+    marginRight: 4,
   },
 });

--- a/components/Library/index.tsx
+++ b/components/Library/index.tsx
@@ -17,6 +17,7 @@ type Props = {
 
 export default function Library(props: Props) {
   const { library } = props;
+  const { github } = library;
 
   return (
     <View style={[styles.container, layout.isSmallScreen() && styles.containerColumn]}>
@@ -33,10 +34,10 @@ export default function Library(props: Props) {
         ) : null}
         <View style={styles.displayHorizontal}>
           <A
-            href={library.githubUrl || library.github.urls.repo}
+            href={library.githubUrl || github.urls.repo}
             style={styles.name}
             hoverStyle={styles.nameHovered}>
-            {library.npmPkg || library.github.name}
+            {library.npmPkg || github.name}
           </A>
           {library.goldstar && (
             <View style={[styles.displayHorizontal, styles.recommendedContainer]}>
@@ -50,25 +51,15 @@ export default function Library(props: Props) {
         <View style={styles.verticalMargin}>
           <CompatibilityTags library={library} />
         </View>
-        {!isEmptyOrNull(library.github.description) && (
+        {!isEmptyOrNull(github.description) && (
           <View style={styles.verticalMargin}>
             <Caption>
               <Linkify component={({ url }) => <A href={url}>{url}</A>}>
-                {emoji.emojify(library.github.description)}
+                {emoji.emojify(github.description)}
               </Linkify>
             </Caption>
           </View>
         )}
-        {library.examples && library.examples.length ? (
-          <View style={[styles.displayHorizontal, styles.verticalMargin]}>
-            <Caption>Code Examples: </Caption>
-            {library.examples.map((example, index) => (
-              <A target="blank" key={example} style={styles.exampleLink} href={example}>
-                <Caption>#{index + 1}</Caption>
-              </A>
-            ))}
-          </View>
-        ) : null}
         {Platform.OS === 'web' && library.images && library.images.length ? (
           <View style={[styles.displayHorizontal, styles.imagesContainer]}>
             {library.images.map((image, index) => (
@@ -76,7 +67,7 @@ export default function Library(props: Props) {
             ))}
           </View>
         ) : null}
-        {library.github.license || library.github.urls.homepage ? (
+        {github.license || github.urls.homepage || (library.examples && library.examples.length) ? (
           <>
             <View style={styles.filler} />
             <View style={styles.bottomBar}>


### PR DESCRIPTION
# Why

This PR moves the codes examples links to the bottom `MetaData` bar. This is the next small step in the library box space optimization efforts (refs #372).

`Code` icon is very generic one, but I don't have the better idea at this moment how to visualize the examples block. If some have one feel free to replace the icon later.

# Preview
<img width="905" alt="Annotation 2020-07-11 194406" src="https://user-images.githubusercontent.com/719641/87230288-34c15500-c3af-11ea-88cf-ea0928648404.png">

# Checklist
If you added a feature or fixed a bug:

- [X] Documented in this PR how you fixed or created the feature.
