### PR TITLE
fix permanently visible image preview when user scrolls the page

### DIFF
--- a/components/Library/Thumbnail.tsx
+++ b/components/Library/Thumbnail.tsx
@@ -21,16 +21,14 @@ const Thumbnail = ({ url }: Props) => {
     strategy: 'fixed',
   });
 
-  const handleMouseEvent = useCallback(() => {
-    setShowPreview(!showPreview);
-  }, [showPreview]);
+  const handleMouseEvent = useCallback(show => setShowPreview(show), [showPreview]);
 
   return (
     <>
       <a
         ref={iconRef}
-        onMouseEnter={handleMouseEvent}
-        onMouseLeave={handleMouseEvent}
+        onMouseEnter={() => handleMouseEvent(true)}
+        onMouseLeave={() => handleMouseEvent(false)}
         style={{
           marginRight: 10,
           marginTop: 4,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

The events to display image preview while hovering a Thumbnail has been adjusted in my last PR (to fix the flickering), but the changed approach caused a new bug. When users have started scrolling while hovering the Thumbnail box the image preview have became permanently visible and disappears only on when Thumbnail was hovered. Alternatively user can just refresh the page.

This PR fixes this issues by sending the preview state in the handler rather than flipping the existing state.

# Checklist

If you added a feature or fixed a bug:

- [X] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.
