### PR TITLE
mark few libraries as unmaintained

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -409,7 +409,8 @@
     "ios": true,
     "android": false,
     "web": false,
-    "expo": false
+    "expo": false,
+    "unmaintained": true    
   },
   {
     "githubUrl": "https://github.com/bietkul/react-reactive-form",
@@ -1039,7 +1040,8 @@
     "githubUrl": "https://github.com/capitalone/react-native-pathjs-charts",
     "ios": true,
     "android": true,
-    "expo": true
+    "expo": true,
+    "unmaintained": true
   },
   {
     "githubUrl": "https://github.com/FormidableLabs/victory-native",
@@ -1136,7 +1138,8 @@
     "githubUrl": "https://github.com/evollu/react-native-fcm",
     "ios": true,
     "android": true,
-    "expo": false
+    "expo": false,
+    "unmaintained": true
   },
   {
     "githubUrl": "https://github.com/crazycodeboy/react-native-easy-toast",
@@ -1226,7 +1229,8 @@
     "ios": true,
     "android": true,
     "expo": true,
-    "examples": ["https://snack.expo.io/Bk8-1FILb"]
+    "examples": ["https://snack.expo.io/Bk8-1FILb"],
+    "unmaintained": true
   },
   {
     "githubUrl": "https://github.com/Spikef/react-native-gesture-password",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

All libraries marked as `unmaintained` are archived on GitHub or have depreactaion notice in the Readme or description:
* https://github.com/prscX/react-native-material-showcase-ios
* https://github.com/capitalone/react-native-pathjs-charts
* https://github.com/evollu/react-native-fcm
* https://github.com/ArnaudRinquin/react-native-radio-buttons
