### PR TITLE
Redeploy app on a schedule

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -3,6 +3,9 @@ name: Deploy to production
 on:
   push:
     branches: [ master ]
+  schedule:
+    # Run every 3 hours
+    - cron: '0 */3 * * *'
 
 jobs:
   build:

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [ master ]
   schedule:
-    # Run every 3 hours
-    - cron: '0 */3 * * *'
+    # Run every 1 hour - https://crontab.guru/#0_*/1_*_*_*
+    - cron: '0 */1 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
Closes #355 

# Why

We display the time since updated on the website, but this only gets updated when the site gets re-deployed meaning it becomes inaccurate fairly quickly

This will trigger a redeploy on a schedule to update the site even if no commits have been merged to it