### PR TITLE
add react-native-testing-library to the directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -3986,8 +3986,7 @@
     "ios": false,
     "android": true,
     "expo": false,
-    "windows": false,
-    "npmPkg": "react-native-modal-dropdown"
+    "windows": false
   },
   {
     "githubUrl": "https://github.com/Shopify/restyle",
@@ -5871,6 +5870,21 @@
     "ios": true,
     "android": true,
     "web": false,
+    "expo": false,
+    "windows": false,
+    "macos": false,
+    "unmaintained": false
+  },
+  {
+    "githubUrl": "https://github.com/callstack/react-native-testing-library",
+    "examples": [
+      "https://github.com/callstack/react-native-testing-library#example",
+      "https://github.com/callstack/react-native-testing-library/tree/master/examples/reactnavigation",
+      "https://github.com/callstack/react-native-testing-library/tree/master/examples/redux"
+    ],
+    "ios": true,
+    "android": true,
+    "web": true,
     "expo": false,
     "windows": false,
     "macos": false,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

This PR adds [`react-native-testing-library`](https://github.com/callstack/react-native-testing-library) to the directory and removes invalid npm package name from the `react-native-modal-translucent` entry.

# Checklist

If you added a new library:

- [X] Added it to **react-native-libraries.json**
