### PR TITLE
Force new deploy even with no changes

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -19,7 +19,7 @@ jobs:
         node-version: '~12.16.3'
     - name: Deploy
       shell: bash
-      run: npx now --token "$VERCEL_TOKEN" --prod
+      run: npx now --force --token "$VERCEL_TOKEN" --prod
       env:
         VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         # https://spectrum.chat/zeit/now/solved-project-linking-and-ci-cd-pipelines~5e6eb62a-9d56-47ac-9e32-0d973a523787


### PR DESCRIPTION
- Triggers rebuild of package info

Follow up to #385 and #355


As there are no code changes the deployment gets skipped on the scheduled runs. This forces it to redeploy anyway.

```
now [options] <command | path>

  Options:

    -h, --help                     Output usage information
    -v, --version                  Output the version number
    ...
    -f, --force                    Force a new deployment even if nothing has changed
```
