### PR TITLE
add react-native-confirmation-code-input library

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -5889,5 +5889,19 @@
     "windows": false,
     "macos": false,
     "unmaintained": false
+  },
+  {
+    "githubUrl": "https://github.com/retyui/react-native-confirmation-code-input",
+    "examples": [
+      "https://snack.expo.io/Zil!jCFft",
+      "https://github.com/retyui/react-native-confirmation-code-field/blob/master/examples/DemoCodeField"
+    ],
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expo": true,
+    "windows": false,
+    "macos": false,
+    "unmaintained": false
   }
 ]


### PR DESCRIPTION
# Why

This PR adds [`react-native-confirmation-code-input`](https://github.com/retyui/react-native-confirmation-code-input) library to the directory.

# Checklist

If you added a new library:

- [X] Added it to **react-native-libraries.json**
