### PR TITLE
do not store last release data for monorepo packages

### DIFF
--- a/scripts/fetch-github-data.js
+++ b/scripts/fetch-github-data.js
@@ -247,11 +247,14 @@ const createRepoDataWithResponse = (json, monorepo) => {
     }
   }
 
+  if (!monorepo) {
+    json.lastRelease =
+      json.releases && json.releases.nodes && json.releases.nodes.length
+        ? json.releases.nodes[0]
+        : undefined;
+  }
+
   const lastCommitAt = json.defaultBranchRef.target.history.nodes[0].committedDate;
-  const lastRelease =
-    json.releases && json.releases.nodes && json.releases.nodes.length
-      ? json.releases.nodes[0]
-      : undefined;
 
   const hasTopics = json.topics && json.topics.length;
   const topics = hasTopics ? json.topics.map(topic => topic.toLowerCase()) : [];
@@ -281,6 +284,6 @@ const createRepoDataWithResponse = (json, monorepo) => {
     description: json.description,
     topics,
     license: json.licenseInfo,
-    lastRelease,
+    lastRelease: json.lastRelease,
   };
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

In #386 I have added an ability to fetch last release data from GitHub. After exploring the data I have realized that storing the release data for the monorepo packages is bad idea which produces invalid data. I going to explore alternative methods or a think about fallback idea, but the fix in this PR should be sufficient for now.

# Checklist

- [X] Documented in this PR how you fixed or created the feature.
