### PR TITLE
add license fetch fallback based on package.json

### DIFF
--- a/scripts/fetch-github-data.js
+++ b/scripts/fetch-github-data.js
@@ -247,7 +247,7 @@ const createRepoDataWithResponse = (json, monorepo) => {
     }
 
     if (!json.licenseInfo || (json.licenseInfo && json.licenseInfo.key === 'other')) {
-      json.licenseInfo = getLicenseFromPackageJson(packageJson);
+      json.licenseInfo = getLicenseFromPackageJson(packageJson) || json.licenseInfo;
     }
   }
 

--- a/scripts/fetch-github-data.js
+++ b/scripts/fetch-github-data.js
@@ -245,6 +245,10 @@ const createRepoDataWithResponse = (json, monorepo) => {
     if (json.topics.length === 0) {
       json.topics = packageJson.keywords;
     }
+
+    if (!json.licenseInfo || (json.licenseInfo && json.licenseInfo.key === 'other')) {
+      json.licenseInfo = getLicenseFromPackageJson(packageJson);
+    }
   }
 
   if (!monorepo) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

This PR adds license fallback for non-monorepo packages based on `package.json`. Fallback is only executed when there is no license fetched from GitHub or GitHub classified license as "other". This should fix most of issues related to the licenses.

# Preview
<img width="387" alt="Annotation 2020-07-20 195033" src="https://user-images.githubusercontent.com/719641/87969435-70040800-cac2-11ea-97b3-f6de5b6ce406.png">

<img width="374" alt="Annotation 2020-07-20 195133" src="https://user-images.githubusercontent.com/719641/87969438-71353500-cac2-11ea-9f0c-66e58f31ece9.png">

# Checklist

- [X] Documented in this PR how you fixed or created the feature.
