### PR TITLE
trim search text to improve search reliability

### DIFF
--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -18,8 +18,8 @@ type Props = {
 export default function Search(props: Props) {
   const { query, total } = props;
   const [isFilterVisible, setFilterVisible] = useState(false);
-  const [debouncedCallback] = useDebouncedCallback(text => {
-    Router.replace(urlWithQuery('/', { ...query, search: text, offset: null }));
+  const [debouncedCallback] = useDebouncedCallback((text: string) => {
+    Router.replace(urlWithQuery('/', { ...query, search: text.trim(), offset: null }));
   }, 150);
 
   return (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

Currently when a keyword or package name have space before or after the text search returns no result. Trimming the search text fixes those issues.

# Checklist

If you added a feature or fixed a bug:

- [X] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.
