### PR TITLE
add react native styling cheat sheet

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -6121,5 +6121,15 @@
     "windows": false,
     "macos": false,
     "unmaintained": false
+  },
+  {
+    "githubUrl": "https://github.com/vhpoet/react-native-styling-cheat-sheet",
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expo": true,
+    "windows": true,
+    "macos": false,
+    "unmaintained": false
   }
 ]


### PR DESCRIPTION
# Why

this PR add  `react-native-styling-cheat-sheet` in json file, this is not a dependency but this is very helpful to find all the css list you can use in `React Native`.!

