### PR TITLE
fix image preview gallery for the few libraries

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -407,6 +407,9 @@
   },
   {
     "githubUrl": "https://github.com/prscX/react-native-material-showcase-ios",
+    "images": [
+      "https://raw.githubusercontent.com/aromajoin/material-showcase-ios/master/art/material-showcase.gif"
+    ],
     "ios": true,
     "android": false,
     "web": false,
@@ -422,6 +425,9 @@
   },
   {
     "githubUrl": "https://github.com/prscX/react-native-taptargetview",
+    "images": [
+      "https://github.com/KeepSafe/TapTargetView/raw/master/.github/video.gif"
+    ],
     "ios": false,
     "android": true,
     "web": false,
@@ -627,6 +633,9 @@
   },
   {
     "githubUrl": "https://github.com/oblador/react-native-vector-icons",
+    "images": [
+      "https://cloud.githubusercontent.com/assets/378279/8903470/a9fe6b46-3458-11e5-901f-98b7b676d0d3.png"
+    ],
     "ios": true,
     "android": true,
     "web": true,
@@ -1864,6 +1873,9 @@
   },
   {
     "githubUrl": "https://github.com/tomauty/react-native-chart",
+    "images": [
+      "https://raw.githubusercontent.com/tomauty/react-native-chart/master/screenshots/README.png"
+    ],
     "ios": true,
     "android": true,
     "unmaintained": true
@@ -2526,6 +2538,9 @@
   },
   {
     "githubUrl": "https://github.com/Nozbe/WatermelonDB",
+    "images": [
+      "https://github.com/Nozbe/WatermelonDB/raw/master/assets/watermelon-demo-thumbnail.png"
+    ],
     "ios": true,
     "android": true,
     "web": true,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

Currently few libraries have a quite long list of image previews, but most of those images are not relevant at all (logos, decorations, badges). Auto scraping the images is a great feature but fixing all the corner cases might be a lengthy process. 

So for now to fix those few libraries I have manually added `"images"` array to the problematic packages which will display only the defined (correct) images instead of performing a scrape.

### Example
<img width="897" alt="prev" src="https://user-images.githubusercontent.com/719641/88424953-cccb2f80-cdee-11ea-8e6b-86fa159e7a08.png">
