### PR TITLE
add react-native-countdown-circle-timer

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -6170,5 +6170,18 @@
     "windows": false,
     "macos": false,
     "unmaintained": false
+  },
+  {
+    "githubUrl": "https://github.com/vydimitrov/react-countdown-circle-timer/tree/master/packages/mobile",
+    "npmPkg": "react-native-countdown-circle-timer",
+    "examples": ["https://snack.expo.io/@vydimitrov/countdown-circle-timer?platform=ios"],
+    "images": [
+      "https://user-images.githubusercontent.com/10707142/66097204-ca68c200-e59d-11e9-9b70-688409755aaa.gif",
+      "https://user-images.githubusercontent.com/10707142/65935516-a0869280-e419-11e9-9bb0-40c4d1ef2bbe.gif",
+      "https://user-images.githubusercontent.com/10707142/65963815-cfbdf380-e45b-11e9-809d-970174e88914.gif"
+    ],
+    "ios": true,
+    "android": true,
+    "expo": true
   }
 ]


### PR DESCRIPTION
# Why

This PR adds a new library/component ` react-native-countdown-circle-timer` to the React Native directory website. The library shares repo with  `react-countdown-circle-timer`, which is the Web version of the component. 

# Checklist

- [x] Added it to **react-native-libraries.json**
