### PR TITLE
fix background color on macOS when scroll reaches top or bottom

### DIFF
--- a/styles/PreviewStyles.tsx
+++ b/styles/PreviewStyles.tsx
@@ -18,20 +18,27 @@ const PreviewStyles = () => {
     <CustomAppearanceContext.Consumer>
       {context => (
         <style jsx global>{`
+          html,
+          body {
+            background-color: ${context.isDark ? darkColors.background : colors.white};
+          }
+
           .preview {
             background-color: ${context.isDark ? darkColors.black : colors.white} !important;
             opacity: 1 !important;
             padding: 10px !important;
             box-sizing: border-box;
-            box-shadow: 0 5px 5px 0 #00000025 !important;
+            box-shadow: 0 4px 6px 0 ${context.isDark ? '#2a2e3633' : '#00000025'} !important;
             max-width: ${previewWidth}px;
             max-height: 66vh;
+            border-radius: 3px;
           }
 
           .preview img {
             display: none;
             max-width: ${previewImageWidth}px;
             max-height: calc(66vh - 20px);
+            border-radius: 2px;
           }
 
           .preview.loaded img {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

This PR fixes an issue with dark mode on macOS (due to Rubber Band / elastic scroll effect) when user reaches the top or bottom of the page. I have used Preview portals global styles for that because creating separate component for those few lines seems unnecessary.

I have also added a small border radius to the preview wrapper and image (to fit the design of other elements) and I have added the separate shadow color for preview wrapper in the dark mode.

### Preview
<img width="339" alt="prev1" src="https://user-images.githubusercontent.com/719641/88853186-9f67f280-d1ef-11ea-9608-0afbb18f3d39.png">

# Checklist

If you added a feature or fixed a bug:

- [X] Documented in this PR how you fixed or created the feature.
