### PR TITLE
move search query normalization to API, lowercase the description on search

### DIFF
--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -20,7 +20,7 @@ export default function Search(props: Props) {
   const { query, total } = props;
   const [isFilterVisible, setFilterVisible] = useState(false);
   const [debouncedCallback] = useDebouncedCallback((text: string) => {
-    Router.replace(urlWithQuery('/', { ...query, search: text.trim(), offset: null }));
+    Router.replace(urlWithQuery('/', { ...query, search: text, offset: null }));
   }, 150);
   const isSmallScreen = layout.isSmallScreen();
 

--- a/pages/api/libraries/index.ts
+++ b/pages/api/libraries/index.ts
@@ -39,10 +39,18 @@ function handler(req: NextApiRequest, res: NextApiResponse) {
 
   let sortBy = getAllowedOrderString(req);
   let libraries = SortedData[sortBy];
+
+  let querySearch = req.query.search
+    ? req.query.search
+        .toString()
+        .toLowerCase()
+        .trim()
+    : undefined;
+
   let filteredLibraries = handleFilterLibraries({
     libraries,
     queryTopic: req.query.topic,
-    querySearch: req.query.search,
+    querySearch,
     support: {
       ios: req.query.ios,
       android: req.query.android,

--- a/util/search.js
+++ b/util/search.js
@@ -92,7 +92,7 @@ export const handleFilterLibraries = ({
         ? library.npmPkg.includes(querySearch)
         : undefined;
       const isDescriptionMatch = !isEmptyOrNull(library.github.description)
-        ? library.github.description.includes(querySearch)
+        ? library.github.description.toLowerCase().includes(querySearch)
         : undefined;
 
       isSearchMatch = isNameMatch || isNpmPkgNameMatch || isDescriptionMatch || isTopicMatch;


### PR DESCRIPTION
# Why

Currently when user enters `hTmL` in the search input there is no results and the same problem occurs with the `search` parameter value in the directory API. 

To fix this issue I have moved the search query normalization to the API side. Besides  the safe conversion and `trim()` I have added the lowercase conversion. The final part of the changes is a lowercase conversion of description when looking for search query in it.

### Preview
<img width="959" alt="Annotation 2020-07-30 115638" src="https://user-images.githubusercontent.com/719641/88909735-c65c0e00-d25b-11ea-96f8-6c20a0c3cbc3.png">

# Checklist

If you added a feature or fixed a bug:

- [X] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.
