### PR TITLE
improve the library Readme images scrapping

### DIFF
--- a/scripts/fetch-readme-images.js
+++ b/scripts/fetch-readme-images.js
@@ -6,12 +6,16 @@ import { sleep } from './build-and-score-data';
 const isLikelyUsefulImage = (image, imageSrc, githubUrl) => {
   let parentHref = image.parent().attr('href');
   let isInHeader = image.parents('h1').length > 0;
-  let isFromRepo = imageSrc.includes(githubUrl);
-  let isBadge = imageSrc.includes('shields.io') || imageSrc.includes('travis-ci.com');
+  let isFromRepo = imageSrc.includes(githubUrl) || imageSrc.startsWith('/');
+  let isAvatar = imageSrc.includes('avatars0.githubusercontent.com');
+  let isBadge =
+    imageSrc.includes('shields.io') ||
+    imageSrc.includes('travis-ci.com') ||
+    imageSrc.includes('badge.svg');
 
   return (
-    (isFromRepo && !isInHeader) ||
-    (parentHref && imageSrc && parentHref === imageSrc && !isInHeader && !isBadge)
+    (isFromRepo && !isInHeader && !isBadge && !isAvatar) ||
+    (parentHref && imageSrc && parentHref === imageSrc && !isInHeader && !isBadge && !isAvatar)
   );
 };
 
@@ -27,7 +31,8 @@ const scrapeImagesAsync = async githubUrl => {
       let image = $(images[i]);
       let imageSrc = image.attr('data-canonical-src') || image.attr('src');
       if (isLikelyUsefulImage(image, imageSrc, githubUrl)) {
-        usefulImages.push(imageSrc);
+        const finalURL = imageSrc.startsWith('/') ? `https://github.com${imageSrc}` : imageSrc;
+        usefulImages.push(finalURL);
       }
     }
     return usefulImages;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

It looks like there are some repositories which uses relative assets paths for the images in the Readme file. This was causing an invalid categorization of images as "not from repository" (`isFromRepo` flag) and dropping them from the list of useful images as result.

This PR fixes that behavior, adds one more trigger string for badge filter and introduce simple users avatar filter based on GitHub avatars CDN URL.

The changes overall should increase the amount of image preview fetched for the libraries.

### Example - https://github.com/react-native-community/lottie-react-native
<img width="469" alt="Annotation 2020-07-30 141037" src="https://user-images.githubusercontent.com/719641/88921248-7cc8ee80-d26e-11ea-8fb3-988d7c1168fc.png">

# Checklist

<!--
Check completed item, when applicable, via: [X]
-->

If you added a new library:

- [ ] Added it to **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [X] Documented in this PR how you fixed or created the feature.
