### PR TITLE
add react-native-image-keyboard to the directory

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -6384,5 +6384,11 @@
     "githubUrl": "https://github.com/Gustash/react-native-siri-shortcut",
     "examples": ["https://github.com/Gustash/react-native-siri-shortcut/tree/master/example"],
     "ios": true
+  },
+  {
+    "githubUrl": "https://github.com/Gustash/react-native-image-keyboard",
+    "examples": ["https://github.com/Gustash/react-native-image-keyboard/tree/master/example"],
+    "ios": true,
+    "android": true
   }
 ]


### PR DESCRIPTION
# Why

This PR adds [react-native-image-keyboard](https://github.com/Gustash/react-native-image-keyboard) to the directory.

# Checklist

If you added a new library:

- [x] Added it to **react-native-libraries.json**