### PR TITLE
add "Development Tool" tag, update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Please follow this format and indentation:
 {
   "githubUrl": "<THE GITHUB URL>",
   "npmPkg": "<NPM PACKAGE NAME>",
+  "nameOverride": "<PACKAGE DISPLAY NAME>",
   "examples": ["<THE URL TO REPO>", "<THE URL TO A SNACK>"],
   "images": ["<PUBLIC URL TO RELATED IMAGE>"],
   "ios": false,
@@ -60,21 +61,24 @@ Please follow this format and indentation:
   "expo": false,
   "windows": false,
   "macos": false,
-  "unmaintained": false
-},
+  "unmaintained": false,
+  "dev": false
+}
 ```
 
-- `githubUrl` - where we can find the repository on GitHub (currently other git hosts are not supported).
-- `npmPkg` - optional string of the package's display name.
-- `examples` - optional array of URLs (snacks preferred) with demonstrations of the library.
-- `images` - optional array of images that will show up in the listing to preview the library functionality.
-- `ios` - works on iOS phones.
-- `android` - works on Android phones.
-- `web` - can be used in the browser.
-- `expo` - can be used in managed workflow, without ejecting an Expo application (any library can be used if you eject).
-- `windows` - can be used with `react-native-windows`.
-- `macos` - can be used with `react-native-macos`.
-- `unmaintained` - optional boolean to signify that a library is or is not maintained.
+- `githubUrl` - (**required** string) - URL to the GitHub repository (currently other git hosts are not supported).
+- `npmPkg` - (_optional_ string) - package's display name (fill only when the GitHub repository name is different from the name of package published to npm).
+- `nameOverride` - (_optional_ string) - override name if the name is different from the GitHub repo and npm package name.
+- `examples` - (_optional_ array of strings) - URLs (snacks preferred) with demonstrations of the library.
+- `images` - (_optional_ array of strings) - URLs to images that will show up in the listing to preview the library functionality.
+- `ios` - (_optional_ boolean) - works on iOS phones.
+- `android` - (_optional_ boolean) - works on Android phones.
+- `web` - (_optional_ boolean) - can be used with [`react-native-web`](https://github.com/necolas/react-native-web).
+- `expo` - (_optional_ boolean) - can be used in managed workflow, without ejecting an [Expo](https://github.com/expo/expo) application (any library can be used if you eject).
+- `windows` - (_optional_ boolean) - can be used with [`react-native-windows`](https://github.com/microsoft/react-native-windows).
+- `macos` - (_optional_ boolean) - can be used with [`react-native-macos`](https://github.com/microsoft/react-native-macos).
+- `unmaintained` - (_optional_ boolean) - signify that a library is not maintained.
+- `dev` - (_optional_ boolean) - signify that a library is a development tool.
 
 > _Note:_ If your package is within a monorepo on GitHub, eg: https://github.com/expo/expo/tree/master/packages/expo-web-browser, then the name, description, homepage, and topics (keywords) will be extracted from package.json for that subrepo. GitHub stats will be based on the monorepo, because there isn't really another option.
 

--- a/components/CompatibilityTags.tsx
+++ b/components/CompatibilityTags.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, ViewStyle } from 'react-native';
 
 import { colors, darkColors, Label } from '../common/styleguide';
 import CustomAppearanceContext from '../context/CustomAppearanceContext';
@@ -9,6 +9,33 @@ import { Check } from './Icons';
 type Props = {
   library: Library;
 };
+
+type TagProps = {
+  platform: string;
+  tagStyle: ViewStyle;
+  showCheck?: boolean;
+};
+
+const Tag = ({ platform, tagStyle, showCheck = true }: TagProps) => (
+  <CustomAppearanceContext.Consumer>
+    {context => (
+      <View key={platform} style={[styles.tag, tagStyle]}>
+        {showCheck ? (
+          <Check width={14} height={10} fill={context.isDark ? darkColors.secondary : undefined} />
+        ) : null}
+        <Label
+          style={[
+            styles.text,
+            {
+              color: context.isDark ? darkColors.secondary : colors.black,
+            },
+          ]}>
+          {platform}
+        </Label>
+      </View>
+    )}
+  </CustomAppearanceContext.Consumer>
+);
 
 export function CompatibilityTags(props: Props) {
   const { library } = props;
@@ -27,31 +54,24 @@ export function CompatibilityTags(props: Props) {
     <CustomAppearanceContext.Consumer>
       {context => (
         <View style={styles.container}>
+          {library.dev ? (
+            <Tag
+              platform="Development Tool"
+              tagStyle={{
+                backgroundColor: context.isDark ? '#2b1c48' : '#e3d8f8',
+                borderColor: context.isDark ? '#482f72' : '#d3c2f2',
+              }}
+              showCheck={false}
+            />
+          ) : null}
           {platforms.map(platform => (
-            <View
-              key={platform}
-              style={[
-                styles.tag,
-                {
-                  backgroundColor: context.isDark ? darkColors.dark : colors.gray1,
-                  borderColor: context.isDark ? darkColors.border : colors.gray2,
-                },
-              ]}>
-              <Check
-                width={14}
-                height={10}
-                fill={context.isDark ? darkColors.secondary : undefined}
-              />
-              <Label
-                style={[
-                  styles.text,
-                  {
-                    color: context.isDark ? darkColors.secondary : colors.black,
-                  },
-                ]}>
-                {platform}
-              </Label>
-            </View>
+            <Tag
+              platform={platform}
+              tagStyle={{
+                backgroundColor: context.isDark ? darkColors.dark : colors.gray1,
+                borderColor: context.isDark ? darkColors.border : colors.gray2,
+              }}
+            />
           ))}
         </View>
       )}

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -2766,19 +2766,22 @@
     "ios": true,
     "android": true,
     "web": true,
-    "expo": true
+    "expo": true,
+    "dev": true
   },
   {
     "githubUrl": "https://github.com/expo/expo/tree/master/packages/jest-expo-enzyme",
     "ios": true,
     "android": true,
     "web": true,
-    "expo": true
+    "expo": true,
+    "dev": true
   },
   {
     "githubUrl": "https://github.com/expo/expo/tree/master/packages/jest-expo-puppeteer",
     "web": true,
-    "expo": true
+    "expo": true,
+    "dev": true
   },
   {
     "githubUrl": "https://github.com/leonelfaugusto/rn-option-select",
@@ -2962,7 +2965,8 @@
     "githubUrl": "https://github.com/infinitered/reactotron",
     "ios": true,
     "android": true,
-    "expo": true
+    "expo": true,
+    "dev": true
   },
   {
     "githubUrl": "https://github.com/infinitered/apisauce",
@@ -4873,7 +4877,8 @@
     ],
     "ios": true,
     "android": true,
-    "web": true
+    "web": true,
+    "dev": true
   },
   {
     "githubUrl": "https://github.com/retyui/react-native-confirmation-code-input",
@@ -5099,7 +5104,9 @@
   },
   {
     "githubUrl": "https://github.com/rgommezz/react-native-scroll-bottom-sheet",
-    "examples": ["https://github.com/rgommezz/react-native-scroll-bottom-sheet/tree/master/example"],
+    "examples": [
+      "https://github.com/rgommezz/react-native-scroll-bottom-sheet/tree/master/example"
+    ],
     "ios": true,
     "android": true,
     "expo": true
@@ -5121,7 +5128,9 @@
   },
   {
     "githubUrl": "https://github.com/thegamenicorus/react-native-phone-input",
-    "examples": ["https://github.com/thegamenicorus/react-native-phone-input/tree/master/examples/BasicExample"],
+    "examples": [
+      "https://github.com/thegamenicorus/react-native-phone-input/tree/master/examples/BasicExample"
+    ],
     "ios": true,
     "android": true
   },

--- a/react-native-libraries.schema.json
+++ b/react-native-libraries.schema.json
@@ -103,6 +103,13 @@
         "default": "",
         "examples": ["react-navigation"],
         "pattern": "^(.*)$"
+      },
+      "dev": {
+        "$id": "#/items/properties/dev",
+        "type": "boolean",
+        "title": "The Development Tool Schema",
+        "default": false,
+        "examples": [true]
       }
     }
   }

--- a/types/index.ts
+++ b/types/index.ts
@@ -27,6 +27,7 @@ export type Library = {
   windows: boolean;
   macos: boolean;
   unmaintained: boolean;
+  dev: boolean;
   github: {
     urls: {
       repo: string;
@@ -74,6 +75,5 @@ export type Library = {
   matchingScoreModifiers: string[];
   topicSearchString: string;
   examples: string[];
-  /* Override name override if the name is different from the GitHub repo and npm package name */
   nameOverride?: string;
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

This PR adds new "Development Tool" tag for libraries that are supposed to be used only in `devDependencies` and are tools which helps during development or streamline/automate the development processes. 

Libraries that I have marked as "Development Tool": 
* `jest-expo`
* `jest-expo-enzyme`
* `jest-expo-puppeteer`
* `reactotron`
* `react-native-testing-library`

It's a good start but probably few more libraries can be found in the directory.

I have also updated the Readme content a bit, I have tried to clarify which options are optional and their descriptions (for example for the web), I have also added `nameOverride` (c3c019d62cf5ed9ec289488530dc386249528e87) and moved the description from the TS types file to Readme. 

Feel free to correct or improve the descriptions, as a non-native speaker I always feel that some parts can be phrased better.

> #426: I have created a new PR because for some reason GitHub do not detected branch recreation even besides the force push (this practice usually works, you can check the hint for reopen button). Probably it's related to the fact that it was a Draft not a regular PR.

### Preview
![dev](https://user-images.githubusercontent.com/719641/89087158-99127b80-d393-11ea-8c28-45804b7c8677.gif)

# Checklist

If you added a feature or fixed a bug:

- [X] Documented in this PR how you fixed or created the feature.
