### PR TITLE
expose RN platforms in the footer

### DIFF
--- a/common/styleguide.tsx
+++ b/common/styleguide.tsx
@@ -113,7 +113,7 @@ type AProps = {
   target?: string;
   href: string;
   children?: ReactNode;
-  hoverStyle?: TextStyle;
+  hoverStyle?: TextStyle | TextStyle[];
 };
 
 export const A = (props: AProps) => {

--- a/components/ContentContainer.tsx
+++ b/components/ContentContainer.tsx
@@ -5,7 +5,7 @@ import { layout } from '../common/styleguide';
 
 type Props = {
   children: ReactNode;
-  style?: ViewStyle;
+  style?: ViewStyle | ViewStyle[];
 };
 
 export default function ContentContainer(props: Props) {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -29,7 +29,7 @@ const Platform = ({ name, pkgName, url, Icon, style }: PlatformProps) => {
       {context => {
         const packageNameStyles = [
           styles.platformPackageName,
-          { backgroundColor: context.isDark ? darkColors.background : colors.gray2 },
+          { backgroundColor: context.isDark ? darkColors.veryDark : colors.gray2 },
         ];
         const packageNameHoverStyle = {
           backgroundColor: context.isDark ? colors.primary : colors.sky,

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,52 +1,176 @@
-import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { FunctionComponent, SVGAttributes } from 'react';
+import { StyleSheet, View, ViewStyle } from 'react-native';
 
-import { A, P, colors, darkColors } from '../common/styleguide';
+import { A, P, colors, darkColors, layout } from '../common/styleguide';
 import ContentContainer from '../components/ContentContainer';
 import CustomAppearanceContext from '../context/CustomAppearanceContext';
+import {
+  PlatformAndroid,
+  PlatformIOS,
+  PlatformMacOS,
+  PlatformTvOS,
+  PlatformWeb,
+  PlatformWindows,
+} from './Icons';
 
-export default function Footer() {
+type PlatformProps = {
+  name: string;
+  pkgName: string;
+  url: string;
+  Icon: FunctionComponent<SVGAttributes<SVGElement>>;
+  style?: ViewStyle;
+};
+
+const Platform = ({ name, pkgName, url, Icon, style }: PlatformProps) => {
+  const isSmallScreen = layout.isSmallScreen();
+
   return (
     <CustomAppearanceContext.Consumer>
-      {context => (
-        <View
-          style={[
-            styles.container,
-            {
-              borderTopColor: context.isDark ? darkColors.border : colors.gray2,
-            },
-          ]}>
-          <ContentContainer>
-            <P style={styles.footerText}>
+      {context => {
+        const packageNameStyles = [
+          styles.platformPackageName,
+          { backgroundColor: context.isDark ? darkColors.background : colors.gray2 },
+        ];
+        const packageNameHoverStyle = {
+          backgroundColor: context.isDark ? colors.primary : colors.sky,
+        };
+        const iconColor = context.isDark ? darkColors.pewter : colors.gray5;
+        const borderLeftColor = context.isDark ? darkColors.border : colors.gray2;
+
+        return (
+          <View
+            style={[
+              styles.platformItem,
+              isSmallScreen
+                ? { borderLeftWidth: 0 }
+                : { borderLeftColor, borderLeftWidth: StyleSheet.hairlineWidth },
+              style,
+            ]}>
+            {React.createElement(Icon, { fill: iconColor, width: 32, height: 32 })}
+            <P style={styles.platformName}>{name}</P>
+            <A href={url} style={packageNameStyles} hoverStyle={packageNameHoverStyle}>
+              {pkgName}
+            </A>
+          </View>
+        );
+      }}
+    </CustomAppearanceContext.Consumer>
+  );
+};
+
+const Footer = () => (
+  <CustomAppearanceContext.Consumer>
+    {context => (
+      <View
+        style={[
+          styles.container,
+          {
+            backgroundColor: context.isDark ? darkColors.subHeader : colors.gray1,
+          },
+        ]}>
+        <ContentContainer>
+          <View style={styles.platformsWrapper}>
+            <Platform
+              name="Android"
+              pkgName="react-native"
+              Icon={PlatformAndroid}
+              url="https://github.com/facebook/react-native#readme"
+              style={{ borderLeftWidth: 0 }}
+            />
+            <Platform
+              name="iOS"
+              pkgName="react-native"
+              Icon={PlatformIOS}
+              url="https://github.com/facebook/react-native#readme"
+            />
+            <Platform
+              name="macOS"
+              pkgName="react-native-macos"
+              Icon={PlatformMacOS}
+              url="https://github.com/microsoft/react-native-macos#readme"
+            />
+            <Platform
+              name="tvOS"
+              pkgName="react-native-tvos"
+              Icon={PlatformTvOS}
+              url="https://github.com/react-native-community/react-native-tvos#readme"
+            />
+            <Platform
+              name="Web"
+              pkgName="react-native-web"
+              Icon={PlatformWeb}
+              url="https://github.com/necolas/react-native-web#readme"
+            />
+            <Platform
+              name="Windows"
+              pkgName="react-native-windows"
+              Icon={PlatformWindows}
+              url="https://github.com/microsoft/react-native-windows#readme"
+            />
+          </View>
+          <View>
+            <P
+              style={[
+                styles.footerText,
+                { color: context.isDark ? darkColors.secondary : colors.gray5 },
+              ]}>
               Missing a library?{' '}
               <A href="https://github.com/react-native-community/react-native-directory#how-do-i-add-a-library">
                 Add it to the directory
               </A>
-              . Want to learn more about React Native? Check out the{' '}
+              .
+            </P>
+            <P
+              style={[
+                styles.footerText,
+                { color: context.isDark ? darkColors.secondary : colors.gray5 },
+              ]}>
+              Want to learn more about React Native? Check out the{' '}
               <A href="https://facebook.github.io/react-native/docs/getting-started.html">
                 official React Native docs
               </A>
               , and <A href="https://expo.io">Expo</A>.
             </P>
-          </ContentContainer>
-        </View>
-      )}
-    </CustomAppearanceContext.Consumer>
-  );
-}
+          </View>
+        </ContentContainer>
+      </View>
+    )}
+  </CustomAppearanceContext.Consumer>
+);
 
-let styles = StyleSheet.create({
+const styles = StyleSheet.create({
   container: {
     width: '100%',
-    padding: 24,
-    paddingLeft: 20,
-    marginBottom: 10,
-    borderTopWidth: 1,
-    marginTop: 10,
+    paddingVertical: 32,
+    marginTop: 12,
   },
   footerText: {
     textAlign: 'center',
-    lineHeight: 22,
+    lineHeight: 32,
     fontSize: 13,
   },
+  platformsWrapper: {
+    flexDirection: 'row',
+    marginTop: 4,
+    justifyContent: 'center',
+    flexWrap: 'wrap',
+  },
+  platformItem: {
+    paddingHorizontal: 24,
+    marginBottom: 28,
+    alignItems: 'center',
+  },
+  platformName: {
+    marginTop: 8,
+  },
+  platformPackageName: {
+    fontSize: 12,
+    fontFamily: 'monospace',
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    lineHeight: 22,
+    marginTop: 8,
+  },
 });
+
+export default Footer;

--- a/components/Icons/index.tsx
+++ b/components/Icons/index.tsx
@@ -285,3 +285,81 @@ export function TypeScript(props: Props) {
     </Svg>
   );
 }
+
+export function PlatformTvOS(props: Props) {
+  const { width = 18, height = 18, fill = colors.black } = props;
+  return (
+    <Svg width={width} height={height} viewBox="0 0 24 24" fill="none">
+      <Path d="M3 5h18v12H3z" opacity=".3" fill={fill} />
+      <Path
+        fill={fill}
+        d="M21 3H3c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h5v2h8v-2h5c1.1 0 1.99-.9 1.99-2L23 5c0-1.1-.9-2-2-2zm0 14H3V5h18v12z"
+      />
+    </Svg>
+  );
+}
+
+export function PlatformMacOS(props: Props) {
+  const { width = 18, height = 18, fill = colors.black } = props;
+  return (
+    <Svg width={width} height={height} viewBox="0 0 24 24" fill="none">
+      <Path d="M4 5h16v11H4z" opacity=".3" fill={fill} />
+      <Path
+        fill={fill}
+        d="M20 18c1.1 0 1.99-.9 1.99-2L22 5c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v11c0 1.1.9 2 2 2H0c0 1.1.9 2 2 2h20c1.1 0 2-.9 2-2h-4zM4 5h16v11H4V5zm8 14c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1z"
+      />
+    </Svg>
+  );
+}
+
+export function PlatformIOS(props: Props) {
+  const { width = 18, height = 18, fill = colors.black } = props;
+  return (
+    <Svg width={width} height={height} viewBox="0 0 24 24" fill="none">
+      <Path d="M7 5h10v14H7z" opacity=".3" fill={fill} />
+      <Path
+        fill={fill}
+        d="M17 1.01L7 1c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-1.99-2-1.99zM17 19H7V5h10v14z"
+      />
+    </Svg>
+  );
+}
+
+export function PlatformAndroid(props: Props) {
+  const { width = 18, height = 18, fill = colors.black } = props;
+  return (
+    <Svg width={width} height={height} viewBox="0 0 24 24" fill="none">
+      <Path
+        fill={fill}
+        d="M6 18c0 .55.45 1 1 1h1v3.5c0 .83.67 1.5 1.5 1.5s1.5-.67 1.5-1.5V19h2v3.5c0 .83.67 1.5 1.5 1.5s1.5-.67 1.5-1.5V19h1c.55 0 1-.45 1-1V8H6v10zM3.5 8C2.67 8 2 8.67 2 9.5v7c0 .83.67 1.5 1.5 1.5S5 17.33 5 16.5v-7C5 8.67 4.33 8 3.5 8zm17 0c-.83 0-1.5.67-1.5 1.5v7c0 .83.67 1.5 1.5 1.5s1.5-.67 1.5-1.5v-7c0-.83-.67-1.5-1.5-1.5zm-4.97-5.84l1.3-1.3c.2-.2.2-.51 0-.71s-.51-.2-.71 0l-1.48 1.48C13.85 1.23 12.95 1 12 1c-.96 0-1.86.23-2.66.63L7.85.15c-.2-.2-.51-.2-.71 0-.2.2-.2.51 0 .71l1.31 1.31C6.97 3.26 6 5.01 6 7h12c0-1.99-.97-3.75-2.47-4.84zM10 5H9V4h1v1zm5 0h-1V4h1v1z"
+      />
+    </Svg>
+  );
+}
+
+export function PlatformWeb(props: Props) {
+  const { width = 18, height = 18, fill = colors.black } = props;
+  return (
+    <Svg width={width} height={height} viewBox="0 0 24 24" fill="none">
+      <rect height="3.5" opacity=".3" width="10.5" x="4" y="9" fill={fill} />
+      <rect height="3.5" opacity=".3" width="10.5" x="4" y="14.5" fill={fill} />
+      <rect height="9" opacity=".3" width="3.5" x="16.5" y="9" fill={fill} />
+      <Path
+        fill={fill}
+        d="M20,4H4C2.9,4,2.01,4.9,2.01,6L2,18c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V6C22,4.9,21.1,4,20,4z M14.5,18L4,18v-3.5h10.5 V18z M14.5,12.5H4V9h10.5V12.5z M20,18l-3.5,0V9H20V18z"
+      />
+    </Svg>
+  );
+}
+
+export function PlatformWindows(props: Props) {
+  const { width = 18, height = 18, fill = colors.black } = props;
+  return (
+    <Svg width={width} height={height} viewBox="0 0 32 32" fill="none">
+      <path
+        fill={fill}
+        d="M0,4.5l13.1-1.8l0,12.6L0,15.5L0,4.5z M13.1,16.8l0,12.6L0,27.7l0-10.9L13.1,16.8z M14.7,2.5L32,0v15.2l-17.3,0.1L14.7,2.5z M32,17l0,15.1l-17.3-2.4l0-12.7L32,17z"
+      />
+    </Svg>
+  );
+}

--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -4235,18 +4235,10 @@
     "android": true
   },
   {
-    "githubUrl": "https://github.com/necolas/react-native-web",
-    "web": true
-  },
-  {
     "githubUrl": "https://github.com/Microsoft/reactxp",
     "ios": true,
     "android": true,
     "web": true
-  },
-  {
-    "githubUrl": "https://github.com/microsoft/react-native-windows",
-    "windows": true
   },
   {
     "githubUrl": "https://github.com/surialabs/react-native-geo-fencing",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

Currently only `web` and `windows` platforms are listed in the directory (as libraries), but I think that all platforms deserve some more exposure on the site (and they won't fit good as libraries too).

So this PR adds the platform tiles to the footer, I have used the [Material Icons](https://material.io/resources/icons/?style=twotone) from Two-Tone set by @brentvatne recommendation. Generic icons were used for Apple platforms because there are no official logos (only the wordmarks which cannot be used). Currently all the links leads to the platform repository Readme.

At the beginning the Expo was also on the list but @brentvatne decided to remove it.

On small screens/mobile devices the container wraps and borders are removed from the between of tiles.

@jonsamp Looking for your review, hope you like the idea! 😉

### Preview
![foo](https://user-images.githubusercontent.com/719641/90197935-80ad5280-ddd0-11ea-832a-7f92a8f4c97f.gif)

# Checklist

If you added a feature or fixed a bug:

- [X] Documented in this PR how you fixed or created the feature.
