### PR TITLE
react-navigation supports Windows/macOS

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -449,6 +449,8 @@
     "android": true,
     "web": true,
     "expo": true,
+    "windows": true,
+    "macos": true,
     "goldstar": true,
     "examples": ["https://snack.expo.io/rJnUK4nrZ"]
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Why

<!--
Does this PR add a feature? Address a bug? Add a new library?

Document your changes here.
-->

As of [this release](https://github.com/react-navigation/react-navigation/releases/tag/%40react-navigation%2Fstack%405.9.0) Windows and macOS are supported by react-navigation. This change updates the library to identify this support.

# Checklist

<!--
Check completed item, when applicable, via: [X]
-->

If you **updated** a new library:

- [X] Updated it in **react-native-libraries.json**

If you added a feature or fixed a bug:

- [ ] Documented in this PR how to use the feature or replicate the bug.
- [ ] Documented in this PR how you fixed or created the feature.

# Questions

When I follow [these instructions](https://github.com/react-native-directory/website#how-do-i-run-my-own-version-locally) to run the website locally I don't see these changes or really any of the recent changes (for example I see only 18 under the `windows` filter rather than the 23 I see on the website [today](https://reactnative.directory/?windows=true)). Are there additional steps to run this that aren't captured in the readme? 

Without the ability to validate locally I have to trust that this change is correct.